### PR TITLE
Improvement for determining the version number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install flake8 importlib-metadata
           export TP_SDK_VERSION=$SDK_VERSION
           python3 setup.py install
       - name: Lint with flake8
@@ -37,7 +37,7 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings.
           flake8 . --count --exit-zero --statistics
-      - name: Install test dependecies
+      - name: Install test dependencies
         run: |
           pip install pytest pytest-mock responses
       - name: Run unit-tests with pytest

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setuptools.setup(
         "Appium-Python-Client==1.0.1",
         "decorator>=4.4.2",
         "requests>=2.24.0",
+        "importlib-metadata>=1.7.0",
     ],
 )

--- a/src/testproject/definitions.py
+++ b/src/testproject/definitions.py
@@ -11,14 +11,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-# The version of the SDK
+from importlib_metadata import metadata, PackageNotFoundError
 import os
+import logging
+
+from src.testproject.sdk.exceptions import SdkException
 
 
 def get_sdk_version() -> str:
-    version = os.environ.get("TP_SDK_VERSION")
+
+    version = None
+
+    try:
+        sdk_metadata = metadata('testproject-python-sdk')
+        version = sdk_metadata['Version']
+    except PackageNotFoundError:
+        # This is OK, it just means that there's no previously installed version available
+        pass
+
+    logging.debug(f"Version read from package metadata: {version}")
+
     if version is None:
-        version = "0.0.1"
+        # we're not dealing with an installed package, build uses an environment variable
+        version = os.environ.get("TP_SDK_VERSION")
+        if version is None:
+            raise SdkException("No SDK version definition found in metadata or environment variable")
+
+        logging.debug(f"Version read from environment variable: {version}")
+
     return version


### PR DESCRIPTION
1. Check in metadata (for regular SDK users)
2. Check in TP_SDK_VERSION environment variable (for building purposes)

If both are not detected, an SdkException is thrown.

Signed-off-by: Bas Dijkstra <bas@ontestautomation.com>