### PR TITLE
Custom capability 'cloud:URL' documentation and CI test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
         env:
           TP_DEV_TOKEN: ${{ secrets.TP_DEV_TOKEN }}
           TP_AGENT_URL: http://localhost:8585
+          TP_CLOUD_URL: ${{ secrets.TP_CLOUD_URL }}
         run: |
           trap 'kill $(jobs -p)' EXIT
           export TP_SDK_VERSION=$SDK_VERSION

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.14] - 2020-08-10
+
+### Added
+
+- Add a custom capability 'cloud:URL' usage documentation.
+
+### Changed
+
+- Ensure that only the `src` folder is included in a distribution.
+
+### Fixed
+
+- Fixed scenario when driver commands were not assigned to proper test.
+- Fixed issue with test names being truncated at first space when running pytest parameterized tests.
+- Fixed Safari driver initialization problem on macOS.
+
 ## [0.63.13] - 2020-07-15
 
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,23 @@ TestProject Agent
 By default, drivers communicate with the local Agent listening on http://localhost:8585.
 This value can be overridden by setting the ``TP_AGENT_URL`` environment variable to the correct Agent address.
 
+
+Remote (Cloud) Driver
+---------------------
+
+By default, TestProject Agent communicates with the local Selenium or Appium server.
+In order to initialize a remote driver for cloud providers such as SauceLabs or BrowserStack,
+a custom capability ``cloud:URL`` should be set, for example:
+
+.. code-block:: python
+
+    def driver():
+        chrome_options = ChromeOptions()
+        chrome_options.set_capability("cloud:URL", "https://{USERNAME}:{PASSWORD}@ondemand.us-west-1.saucelabs.com:443/wd/hub")
+        driver = webdriver.Chrome(chrome_options=chrome_options, projectname="Examples")
+        yield driver
+        driver.quit()
+
 Reports
 =======
 By default, the TestProject SDK reports all executed driver commands and their results to the TestProject Cloud.

--- a/src/testproject/sdk/internal/helpers/custom_appium_command_executor.py
+++ b/src/testproject/sdk/internal/helpers/custom_appium_command_executor.py
@@ -57,9 +57,7 @@ class CustomAppiumCommandExecutor(AppiumConnection, ReportingCommandExecutor):
 
         result = response.get("value")
 
-        # Both None and 0 response status values indicate command execution was OK
-        # 0 seems to be returned on some iOS commands
-        passed = True if response.get("status") in [None, 0] else False
+        passed = self.is_command_passed(response=response)
 
         if not skip_reporting:
             self._report_command(command, params, result, passed)

--- a/src/testproject/sdk/internal/helpers/custom_command_executor.py
+++ b/src/testproject/sdk/internal/helpers/custom_command_executor.py
@@ -52,7 +52,7 @@ class CustomCommandExecutor(RemoteConnection, ReportingCommandExecutor):
 
         result = response.get("value")
 
-        passed = True if response.get("status") is None else False
+        passed = self.is_command_passed(response=response)
 
         if not skip_reporting:
             self._report_command(command, params, result, passed)

--- a/src/testproject/sdk/internal/helpers/reporting_command_executor.py
+++ b/src/testproject/sdk/internal/helpers/reporting_command_executor.py
@@ -197,3 +197,15 @@ class ReportingCommandExecutor:
                 # report the stashed command and clear it
                 self.agent_client.report_driver_command(self._stashed_command)
                 self._stashed_command = None
+
+    def is_command_passed(self, response: dict) -> bool:
+        """Determine command result based on response using state and status.
+
+        Args:
+            response (dict): The response returned by the Selenium remote webdriver server
+
+        Returns:
+            bool: True if passed, otherwise False.
+        """
+        # Both None and 0 response status values indicate command execution was OK
+        return True if response.get("status") in [None, 0] else False

--- a/tests/ci/headless/cloud_basic_test.py
+++ b/tests/ci/headless/cloud_basic_test.py
@@ -1,0 +1,39 @@
+# Copyright 2020 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import os
+
+from src.testproject.sdk.drivers import webdriver
+from selenium.webdriver import ChromeOptions
+from tests.pageobjects.web import LoginPage, ProfilePage
+
+
+@pytest.fixture
+def driver():
+    chrome_options = ChromeOptions()
+    chrome_options.headless = True
+    chrome_options.set_capability("cloud:URL", os.getenv("TP_CLOUD_URL"))
+    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    yield driver
+    driver.quit()
+
+
+def test_update_profile_expect_success_message_to_be_displayed(driver):
+
+    LoginPage(driver).open().login_as("John Smith", "12345")
+    ProfilePage(driver).update_profile(
+        country="Australia", address="Main Street 123", email="john@smith.org", phone="+1987654321",
+    )
+    assert ProfilePage(driver).saved_message_is_displayed()


### PR DESCRIPTION
If cloud:URL is capability set, Agent (0.63.11+) will attempt to initialize a driver using provided URL of a cloud provider such as BrowserStack or SauceLabs.