### PR TITLE
Add 'packaging' as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setuptools.setup(
         "decorator>=4.4.2",
         "requests>=2.24.0",
         "importlib-metadata>=1.7.0",
+        "packaging>=20.4"
     ],
 )


### PR DESCRIPTION
This PR adds `packaging` as a dependency, which is used to determine whether the current Agent version supports the use of a generic (non-UI) driver.

Signed-off-by: Bas Dijkstra <bas@ontestautomation.com>