### PR TITLE
Add Python 3.9 to CI Matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -54,19 +54,19 @@ jobs:
         run: |
           pytest tests/ci/unittests --doctest-modules --junitxml=build/reports/junit/unit-test-results-${{ matrix.python-version }}.xml
       - name: Check distribution package validity
-        if: matrix.python-version == '3.8'
+        if: matrix.python-version == '3.9'
         run: |
           pip install twine
           python -m twine check dist/*
       - name: Run TestProject Agent
-        if: matrix.python-version == '3.8'
+        if: matrix.python-version == '3.9'
         env:
           TP_API_KEY: ${{ secrets.TP_API_KEY }}
         run: |
           envsubst < .github/ci/docker-compose.yml > docker-compose.yml
           docker-compose -f docker-compose.yml up -d
       - name: Wait for Agent to Register
-        if: matrix.python-version == '3.8'
+        if: matrix.python-version == '3.9'
         run: |
           trap 'kill $(jobs -p)' EXIT
 
@@ -84,7 +84,7 @@ jobs:
             sleep 1
           done
       - name: Run flow tests
-        if: matrix.python-version == '3.8'
+        if: matrix.python-version == '3.9'
         env:
           TP_DEV_TOKEN: ${{ secrets.TP_DEV_TOKEN }}
           TP_AGENT_URL: http://localhost:8585
@@ -95,7 +95,7 @@ jobs:
           docker-compose -f docker-compose.yml logs -f --tail=0 >> build/reports/agent/log.txt&
           pytest tests/ci/headless --doctest-modules --junitxml=build/reports/junit/flow-test-results-${{ matrix.python-version }}.xml
       - name: Publish to TestPyPI
-        if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/heads/master')
+        if: matrix.python-version == '3.9' && startsWith(github.ref, 'refs/heads/master')
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TWINE_TESTPYPI_PASSWORD }}
@@ -105,7 +105,7 @@ jobs:
           python setup.py clean sdist bdist_wheel
           python -m twine upload --non-interactive --repository testpypi dist/*
       - name: Publish to PyPI
-        if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/tags/v')
+        if: matrix.python-version == '3.9' && startsWith(github.ref, 'refs/tags/v')
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TWINE_PYPI_PASSWORD }}


### PR DESCRIPTION
Add Python 3.9 to the Python version matrix.
Tests and PyPI steps will now use Python 3.9.