### PR TITLE
Allow latest version of Appium to be installed with SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "selenium==3.141.0",
-        "Appium-Python-Client==1.0.1",
+        "Appium-Python-Client>=1.0.1",
         "decorator>=4.4.2",
         "requests>=2.24.0",
         "importlib-metadata>=1.7.0",


### PR DESCRIPTION
This PR allows for Appium-Python-Client versions >= 1.0.1 to be installed as a dependency when the SDK is installed (this was fixed to 1.0.1)