### PR TITLE
Fix/issue 75 missing browser exception

### DIFF
--- a/src/testproject/sdk/exceptions/__init__.py
+++ b/src/testproject/sdk/exceptions/__init__.py
@@ -2,5 +2,12 @@ from .sdkexception import SdkException
 from .agentconnectexception import AgentConnectException
 from .invalidtokenexception import InvalidTokenException
 from .obsoleteversionexception import ObsoleteVersionException
+from .missingbrowserexception import MissingBrowserException
 
-__all__ = ["SdkException", "AgentConnectException", "InvalidTokenException", "ObsoleteVersionException"]
+__all__ = [
+    "SdkException",
+    "AgentConnectException",
+    "InvalidTokenException",
+    "ObsoleteVersionException",
+    "MissingBrowserException",
+]

--- a/src/testproject/sdk/exceptions/missingbrowserexception.py
+++ b/src/testproject/sdk/exceptions/missingbrowserexception.py
@@ -1,0 +1,19 @@
+# Copyright 2020 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class MissingBrowserException(Exception):
+    """Custom exception type to be raised when requested browser is not installed on machine"""
+
+    pass


### PR DESCRIPTION
This PR adds additional error handling on session start: if the Agent returns HTTP 404 (when the requested browser cannot be found) it now returns a suitable error message and raises a `MissingBrowserException` to better inform the user.