### PR TITLE
Add extra argument to driver constructors to allow passing desired se…

### DIFF
--- a/src/testproject/sdk/drivers/webdriver/chrome.py
+++ b/src/testproject/sdk/drivers/webdriver/chrome.py
@@ -21,6 +21,7 @@ class Chrome(BaseDriver):
 
     Args:
         chrome_options (ChromeOptions): Chrome automation session desired capabilities and options
+        desired_capabilities (dict): Dictionary object containing desired capabilities for Chrome automation session
         token (str): The developer token used to communicate with the agent
         projectname (str): Project name to report
         jobname (str): Job name to report
@@ -29,14 +30,22 @@ class Chrome(BaseDriver):
 
     def __init__(
         self,
-        chrome_options: ChromeOptions = ChromeOptions(),
+        chrome_options: ChromeOptions = None,
+        desired_capabilities: dict = None,
         token: str = None,
         projectname: str = None,
         jobname: str = None,
         disable_reports: bool = False,
     ):
+        # Specified ChromeOptions take precedence over desired capabilities but either can be used
+        caps = (
+            chrome_options.to_capabilities()
+            if chrome_options is not None
+            else desired_capabilities
+        )
+
         super().__init__(
-            capabilities=chrome_options.to_capabilities(),
+            capabilities=caps,
             token=token,
             projectname=projectname,
             jobname=jobname,

--- a/src/testproject/sdk/drivers/webdriver/edge.py
+++ b/src/testproject/sdk/drivers/webdriver/edge.py
@@ -21,6 +21,7 @@ class Edge(BaseDriver):
 
     Args:
         edge_options (Options): Edge automation session desired capabilities and options
+        desired_capabilities (dict): Dictionary object containing desired capabilities for Chrome automation session
         token (str): The developer token used to communicate with the agent
         projectname (str): Project name to report
         jobname (str): Job name to report
@@ -29,14 +30,22 @@ class Edge(BaseDriver):
 
     def __init__(
         self,
-        edge_options: Options = Options(),
+        edge_options: Options = None,
+        desired_capabilities: dict = None,
         token: str = None,
         projectname: str = None,
         jobname: str = None,
         disable_reports: bool = False,
     ):
+        # Specified EdgeOptions take precedence over desired capabilities but either can be used
+        caps = (
+            edge_options.to_capabilities()
+            if edge_options is not None
+            else desired_capabilities
+        )
+
         super().__init__(
-            capabilities=edge_options.to_capabilities(),
+            capabilities=caps,
             token=token,
             projectname=projectname,
             jobname=jobname,

--- a/src/testproject/sdk/drivers/webdriver/firefox.py
+++ b/src/testproject/sdk/drivers/webdriver/firefox.py
@@ -21,6 +21,7 @@ class Firefox(BaseDriver):
 
     Args:
         firefox_options (FirefoxOptions): Edge automation session desired capabilities and options
+        desired_capabilities (dict): Dictionary object containing desired capabilities for Firefox automation session
         token (str): The developer token used to communicate with the agent
         projectname (str): Project name to report
         jobname (str): Job name to report
@@ -29,14 +30,22 @@ class Firefox(BaseDriver):
 
     def __init__(
         self,
-        firefox_options: FirefoxOptions = FirefoxOptions(),
+        firefox_options: FirefoxOptions = None,
+        desired_capabilities: dict = None,
         token: str = None,
         projectname: str = None,
         jobname: str = None,
         disable_reports: bool = False,
     ):
+        # Specified FirefoxOptions take precedence over desired capabilities but either can be used
+        caps = (
+            firefox_options.to_capabilities()
+            if firefox_options is not None
+            else desired_capabilities
+        )
+
         super().__init__(
-            capabilities=firefox_options.to_capabilities(),
+            capabilities=caps,
             token=token,
             projectname=projectname,
             jobname=jobname,

--- a/src/testproject/sdk/drivers/webdriver/ie.py
+++ b/src/testproject/sdk/drivers/webdriver/ie.py
@@ -21,6 +21,7 @@ class Ie(BaseDriver):
 
     Args:
         ie_options (Options): IE automation session desired capabilities and options
+        desired_capabilities (dict): Dictionary object containing desired capabilities for IE automation session
         token (str): The developer token used to communicate with the agent
         projectname (str): Project name to report
         jobname (str): Job name to report
@@ -29,14 +30,22 @@ class Ie(BaseDriver):
 
     def __init__(
         self,
-        ie_options: Options = Options(),
+        ie_options: Options = None,
+        desired_capabilities: dict = None,
         token: str = None,
         projectname: str = None,
         jobname: str = None,
         disable_reports: bool = False,
     ):
+        # Specified IE Options take precedence over desired capabilities but either can be used
+        caps = (
+            ie_options.to_capabilities()
+            if ie_options is not None
+            else desired_capabilities
+        )
+
         super().__init__(
-            capabilities=ie_options.to_capabilities(),
+            capabilities=caps,
             token=token,
             projectname=projectname,
             jobname=jobname,


### PR DESCRIPTION
This PR adds the option to specify desired capabilities directly as a Python dictionary (next to the existing Options option) when creating a Chrome, Firefox, Edge or IE session.