### PR TITLE
Use default options when no options or desired capabilities are speci…

### DIFF
--- a/src/testproject/sdk/drivers/webdriver/chrome.py
+++ b/src/testproject/sdk/drivers/webdriver/chrome.py
@@ -37,12 +37,16 @@ class Chrome(BaseDriver):
         jobname: str = None,
         disable_reports: bool = False,
     ):
-        # Specified ChromeOptions take precedence over desired capabilities but either can be used
-        caps = (
-            chrome_options.to_capabilities()
-            if chrome_options is not None
-            else desired_capabilities
-        )
+        # If no options or capabilities are specified at all, use default ChromeOptions
+        if chrome_options is None and desired_capabilities is None:
+            caps = ChromeOptions().to_capabilities()
+        else:
+            # Specified ChromeOptions take precedence over desired capabilities but either can be used
+            caps = (
+                chrome_options.to_capabilities()
+                if chrome_options is not None
+                else desired_capabilities
+            )
 
         super().__init__(
             capabilities=caps,

--- a/src/testproject/sdk/drivers/webdriver/edge.py
+++ b/src/testproject/sdk/drivers/webdriver/edge.py
@@ -37,12 +37,16 @@ class Edge(BaseDriver):
         jobname: str = None,
         disable_reports: bool = False,
     ):
-        # Specified EdgeOptions take precedence over desired capabilities but either can be used
-        caps = (
-            edge_options.to_capabilities()
-            if edge_options is not None
-            else desired_capabilities
-        )
+        # If no options or capabilities are specified at all, use default Options
+        if edge_options is None and desired_capabilities is None:
+            caps = Options().to_capabilities()
+        else:
+            # Specified EdgeOptions take precedence over desired capabilities but either can be used
+            caps = (
+                edge_options.to_capabilities()
+                if edge_options is not None
+                else desired_capabilities
+            )
 
         super().__init__(
             capabilities=caps,

--- a/src/testproject/sdk/drivers/webdriver/firefox.py
+++ b/src/testproject/sdk/drivers/webdriver/firefox.py
@@ -37,12 +37,16 @@ class Firefox(BaseDriver):
         jobname: str = None,
         disable_reports: bool = False,
     ):
-        # Specified FirefoxOptions take precedence over desired capabilities but either can be used
-        caps = (
-            firefox_options.to_capabilities()
-            if firefox_options is not None
-            else desired_capabilities
-        )
+        # If no options or capabilities are specified at all, use default FirefoxOptions
+        if firefox_options is None and desired_capabilities is None:
+            caps = FirefoxOptions().to_capabilities()
+        else:
+            # Specified FirefoxOptions take precedence over desired capabilities but either can be used
+            caps = (
+                firefox_options.to_capabilities()
+                if firefox_options is not None
+                else desired_capabilities
+            )
 
         super().__init__(
             capabilities=caps,

--- a/src/testproject/sdk/drivers/webdriver/ie.py
+++ b/src/testproject/sdk/drivers/webdriver/ie.py
@@ -37,12 +37,16 @@ class Ie(BaseDriver):
         jobname: str = None,
         disable_reports: bool = False,
     ):
-        # Specified IE Options take precedence over desired capabilities but either can be used
-        caps = (
-            ie_options.to_capabilities()
-            if ie_options is not None
-            else desired_capabilities
-        )
+        # If no options or capabilities are specified at all, use default Options
+        if ie_options is None and desired_capabilities is None:
+            caps = Options().to_capabilities()
+        else:
+            # Specified IE Options take precedence over desired capabilities but either can be used
+            caps = (
+                ie_options.to_capabilities()
+                if ie_options is not None
+                else desired_capabilities
+            )
 
         super().__init__(
             capabilities=caps,

--- a/tests/ci/headless/chrome_no_options_or_caps_test.py
+++ b/tests/ci/headless/chrome_no_options_or_caps_test.py
@@ -1,0 +1,34 @@
+# Copyright 2020 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from src.testproject.sdk.drivers import webdriver
+from tests.pageobjects.web import LoginPage, ProfilePage
+
+
+@pytest.fixture
+def driver():
+    driver = webdriver.Chrome(projectname="CI - Python")
+    yield driver
+    driver.quit()
+
+
+def test_update_profile_expect_success_message_to_be_displayed(driver):
+
+    LoginPage(driver).open().login_as("John Smith", "12345")
+    ProfilePage(driver).update_profile(
+        country="Australia", address="Main Street 123", email="john@smith.org", phone="+1987654321",
+    )
+    assert ProfilePage(driver).saved_message_is_displayed()


### PR DESCRIPTION
This PR fixes the issue where the Agent rejects the session request when neither options nor capabilities are specified when creating a new driver (introduced by #79).