### PR TITLE
Fix/update capability name for generic driver

### DIFF
--- a/src/testproject/sdk/drivers/webdriver/generic.py
+++ b/src/testproject/sdk/drivers/webdriver/generic.py
@@ -88,7 +88,7 @@ class Generic:
 
         reportsettings = ReportSettings(self._projectname, self._jobname)
 
-        capabilities = {"platform": "ANY"}
+        capabilities = {"platformName": "ANY"}
 
         self._agent_client: AgentClient = AgentClient(
             token=self._token, capabilities=capabilities, reportsettings=reportsettings,


### PR DESCRIPTION
This PR fixes an issue where generic driver sessions could no longer be created from Agent `0.65.10` onwards. The `platform` capability has been renamed to `platformName` to align with standard.

I've also added a generic driver test to the CI suite to ensure that this driver keeps working.