### PR TITLE
Adding optional 'screenshot' argument to the decorator.

### DIFF
--- a/src/testproject/decorator/report_assertion_errors.py
+++ b/src/testproject/decorator/report_assertion_errors.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
+
 import os
 import re
 import sys
 import traceback
+from functools import wraps
 
 from src.testproject.sdk.exceptions import SdkException
 
@@ -25,41 +26,47 @@ from src.testproject.sdk.drivers.webdriver import Remote, Generic
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
 
 
-def report_assertion_errors(func):
-    """Enables automatic logging of failed assertions, including a screenshot"""
+def report_assertion_errors(func=None, *, screenshot: bool = False):
+    """Enables automatic logging of failed assertions, including a screenshot when screenshot argument is True."""
 
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except AssertionError as ae:
-            _, _, tb = sys.exc_info()
-            tb_info = traceback.extract_tb(tb)
+    def _report_assertion_errors(_func):
+        @wraps(_func)
+        def wrapper(*args, **kwargs):
+            try:
+                return _func(*args, **kwargs)
+            except AssertionError as ae:
+                _, _, tb = sys.exc_info()
+                tb_info = traceback.extract_tb(tb)
 
-            # Depending on the unit testing framework in use we need a different line in the stack
-            line_index = -1 if os.getenv("PYTEST_CURRENT_TEST") is not None else -2
+                # Depending on the unit testing framework in use we need a different line in the stack
+                line_index = -1 if os.getenv("PYTEST_CURRENT_TEST") is not None else -2
 
-            # Depending on the unit testing framework we format the reported error differently
-            description = (
-                ae.__repr__()
-                if os.getenv("PYTEST_CURRENT_TEST") is not None
-                else str(ae)
-            )
+                # Depending on the unit testing framework we format the reported error differently
+                description = (
+                    ae.__repr__()
+                    if os.getenv("PYTEST_CURRENT_TEST") is not None
+                    else str(ae)
+                )
 
-            _, line, function, text = tb_info[line_index]
-            driver = __get_active_driver_instance()
-            message = f"Assertion failed on line {line} in {function}"
-            description, message = __handle_step_report_details(description, message)
-            driver.report().step(
-                description=description,
-                message=f"Assertion failed on line {line} in {function}",
-                passed=False,
-                screenshot=False,
-            )
-            # raise the AssertionError again to make the test execution fail as intended
-            raise ae
+                _, line, function, text = tb_info[line_index]
+                driver = __get_active_driver_instance()
+                message = f"Assertion failed on line {line} in {function}"
+                description, message = __handle_step_report_details(description, message)
+                driver.report().step(
+                    description=description,
+                    message=f"Assertion failed on line {line} in {function}",
+                    passed=False,
+                    screenshot=screenshot,
+                )
+                # raise the AssertionError again to make the test execution fail as intended
+                raise ae
 
-    return wrapper
+        return wrapper
+
+    if func:
+        return _report_assertion_errors(func)
+
+    return _report_assertion_errors
 
 
 def __get_active_driver_instance():


### PR DESCRIPTION
When screenshot is True, the assertion error report will take a screenshot.

Signed-off-by: Tzah Mazuz <tzah.mazuz@testproject.io>