### PR TITLE
Issue 89 - Handling response messages coming back from the Agent on response 404.

### DIFF
--- a/src/testproject/executionresults/operationresult.py
+++ b/src/testproject/executionresults/operationresult.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
 
 
 class OperationResult:
@@ -20,16 +21,16 @@ class OperationResult:
         passed (bool): True if the operation was executed successfully, False otherwise
         status_code (int): The HTTP status code of the Agent response
         message (str): A message returned by the Agent after the operation execution
-        data (str): Output data for the operation performed
+        data (Optional[dict]): Output data for the operation performed
 
     Attributes:
         _passed (bool): True if the operation was executed successfully, False otherwise
         _status_code (int): The HTTP status code of the Agent response
         _message (str): A message returned by the Agent after the operation execution
-        _data (str): Output data for the operation performed
+        _data (Optional[dict]): Output data for the operation performed
 
     """
-    def __init__(self, passed: bool = False, status_code: int = 500, message: str = "", data=None):
+    def __init__(self, passed: bool = False, status_code: int = 500, message: str = "", data: Optional[dict] = None):
         self._passed = passed
         self._status_code = status_code
         self._message = message

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 import logging
-import requests
-import threading
 import queue
+import threading
 import uuid
-
-from urllib.parse import urljoin
 from enum import Enum, unique
-from requests import HTTPError
+from http import HTTPStatus
+from urllib.parse import urljoin
+
+import requests
 from packaging import version
+from requests import HTTPError
+
 from src.testproject.classes import ActionExecutionResponse
 from src.testproject.classes.resultfield import ResultField
 from src.testproject.enums import ExecutionResultType


### PR DESCRIPTION
**Previously** the SDK would ignore the response body coming back from the Agent.
Ignoring the body is fine only if the body is empty.

**Now** the SDK will use the response and will raise a more generic exception with the response's message.
When there is no response body or message, it will show a more generic message in the exception.