### PR TITLE
Issue 101 - Fixing 'report' decorator.

### DIFF
--- a/src/testproject/helpers/reporthelper.py
+++ b/src/testproject/helpers/reporthelper.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import ntpath
 import os
 import inspect
 
@@ -118,12 +119,14 @@ class ReportHelper:
         Returns:
             str: the inferred report naming element value
         """
+        path_to_test_file = pytest_info.split(" ")[0].split("::")[0]
         if element_to_find == ReportNamingElement.Project:
-            path_to_test_file = pytest_info.split(" ")[0].split("::")[0]
-            return path_to_test_file[0 : path_to_test_file.rfind("/")].replace("/", ".")
+            # Return the path without base file name parsed as "package".s
+            return path_to_test_file[0: path_to_test_file.rfind("/")].replace("/", ".")
         elif element_to_find == ReportNamingElement.Job:
-            path_to_test_file = pytest_info.split(" ")[0].split("::")[0]
-            return path_to_test_file.split("::")[0].split("/")[-1].split(".py")[0]
+            # Return the base file name without '.py' extension.
+            head, tail = ntpath.split(path_to_test_file)
+            return (tail or ntpath.basename(head)).split(".py")[0]
         elif element_to_find == ReportNamingElement.Test:
             return pytest_info.rsplit(" ", maxsplit=1)[0].split("::")[1]
         return None

--- a/src/testproject/rest/messages/sessionrequest.py
+++ b/src/testproject/rest/messages/sessionrequest.py
@@ -21,28 +21,28 @@ class SessionRequest:
 
     Args:
         capabilities (dict): Desired session capabilities
-        reportsettings (ReportSettings): Settings to be used in the report
+        report_settings (ReportSettings): Settings to be used in the report
 
     Attributes:
         _capabilities (dict): Desired session capabilities
         _sdk_version (str): Current Python SDK version
         _language (str): Test code language (Python, obviously)
-        _projectname (str): Project name to report
-        _jobname (str): Job name to report
+        _project_name (str): Project name to report
+        _job_name (str): Job name to report
     """
 
-    def __init__(self, capabilities: dict, reportsettings: ReportSettings):
+    def __init__(self, capabilities: dict, report_settings: ReportSettings):
         self._capabilities: dict = capabilities
         self._sdk_version = ConfigHelper.get_sdk_version()
         self._language = "Python"
-        self._projectname = reportsettings.projectname
-        self._jobname = reportsettings.jobname
+        self._project_name = report_settings.project_name
+        self._job_name = report_settings.job_name
 
     def to_json(self):
         """Returns a JSON representation of the current SessionRequest instance"""
         return {
-            "projectName": self._projectname,
-            "jobName": self._jobname,
+            "projectName": self._project_name,
+            "jobName": self._job_name,
             "capabilities": self._capabilities,
             "sdkVersion": self._sdk_version,
             "language": self._language,

--- a/src/testproject/rest/reportsettings.py
+++ b/src/testproject/rest/reportsettings.py
@@ -34,10 +34,20 @@ class ReportSettings:
         """Getter for the project name"""
         return self._project_name
 
+    @project_name.setter
+    def project_name(self, new_name: str):
+        """Setter for the project name"""
+        self._project_name = new_name
+
     @property
     def job_name(self) -> str:
         """Getter for the job name"""
         return self._job_name
+
+    @job_name.setter
+    def job_name(self, new_name: str):
+        """Setter for the job name"""
+        self._job_name = new_name
 
     def __eq__(self, other):
         """Custom equality function"""

--- a/src/testproject/rest/reportsettings.py
+++ b/src/testproject/rest/reportsettings.py
@@ -17,37 +17,35 @@ class ReportSettings:
     """Contains settings to be used in the report.
 
         Args:
-            projectname (str): Project name to report
-            jobname (str): Job name to report
+            project_name (str): Project name to report
+            job_name (str): Job name to report
 
         Attributes:
-            _projectname (str): Project name to report
-            _jobname (str): Job name to report
+            _project_name (str): Project name to report
+            _job_name (str): Job name to report
     """
 
-    def __init__(self, projectname: str, jobname: str):
-        self._projectname = projectname
-        self._jobname = jobname
+    def __init__(self, project_name: str, job_name: str):
+        self._project_name = project_name
+        self._job_name = job_name
 
     @property
-    def projectname(self):
+    def project_name(self) -> str:
         """Getter for the project name"""
-        return self._projectname
+        return self._project_name
 
     @property
-    def jobname(self):
+    def job_name(self) -> str:
         """Getter for the job name"""
-        return self._jobname
+        return self._job_name
 
     def __eq__(self, other):
         """Custom equality function"""
         if not isinstance(other, ReportSettings):
             return NotImplemented
 
-        return (
-            self._projectname == other._projectname and self._jobname == other._jobname
-        )
+        return self._project_name == other._project_name and self._job_name == other._job_name
 
     def __hash__(self):
         """Implement hash to allow objects to be used in sets and dicts"""
-        return hash((self._projectname, self._jobname))
+        return hash((self._project_name, self._job_name))

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -83,7 +83,7 @@ class BaseDriver(RemoteWebDriver):
         self._agent_client: AgentClient = AgentClient(
             token=self._token,
             capabilities=capabilities,
-            reportsettings=ReportSettings(self._projectname, self._jobname),
+            report_settings=ReportSettings(self._projectname, self._jobname),
         )
         self._agent_session: AgentSession = self._agent_client.agent_session
         self.w3c = True if self._agent_session.dialect == "W3C" else False

--- a/src/testproject/sdk/drivers/webdriver/generic.py
+++ b/src/testproject/sdk/drivers/webdriver/generic.py
@@ -91,7 +91,7 @@ class Generic:
         capabilities = {"platformName": "ANY"}
 
         self._agent_client: AgentClient = AgentClient(
-            token=self._token, capabilities=capabilities, reportsettings=reportsettings,
+            token=self._token, capabilities=capabilities, report_settings=reportsettings,
         )
         self._agent_session: AgentSession = self._agent_client.agent_session
 

--- a/src/testproject/sdk/drivers/webdriver/remote.py
+++ b/src/testproject/sdk/drivers/webdriver/remote.py
@@ -33,8 +33,8 @@ class Remote(AppiumWebDriver):
     Args:
         desired_capabilities (dict): Automation session desired capabilities and options
         token (str): Developer token to be used to communicate with the Agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
 
     Attributes:
@@ -52,8 +52,8 @@ class Remote(AppiumWebDriver):
         self,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         if Remote.__instance is not None:
@@ -67,24 +67,24 @@ class Remote(AppiumWebDriver):
 
         if disable_reports:
             # Setting the project and job name to empty strings will cause the Agent to not initialize a report
-            self._projectname = ""
-            self._jobname = ""
+            self._project_name = ""
+            self._job_name = ""
         else:
-            self._projectname = (
-                projectname
-                if projectname is not None
+            self._project_name = (
+                project_name
+                if project_name is not None
                 else ReportHelper.infer_project_name()
             )
-            self._jobname = (
-                jobname if jobname is not None else ReportHelper.infer_job_name()
+            self._job_name = (
+                job_name if job_name is not None else ReportHelper.infer_job_name()
             )
 
-        reportsettings = ReportSettings(self._projectname, self._jobname)
+        report_settings = ReportSettings(self._project_name, self._job_name)
 
         self._agent_client: AgentClient = AgentClient(
             token=self._token,
             capabilities=self._desired_capabilities,
-            reportsettings=reportsettings,
+            report_settings=report_settings,
         )
         self._agent_session: AgentSession = self._agent_client.agent_session
         self.w3c = True if self._agent_session.dialect == "W3C" else False

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -97,6 +97,11 @@ class AgentClient:
         """Getter for the Agent session object"""
         return self._agent_session
 
+    @property
+    def report_settings(self) -> ReportSettings:
+        """Getter for the Report settings object."""
+        return self._report_settings
+
     def __start_session(self) -> bool:
         """Starts a new development session with the Agent
 

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -56,14 +56,14 @@ class AgentClient:
     Args:
         token (str): The development token used to communicate with the Agent
         capabilities (dict): Additional options to be applied to the driver instance
-        reportsettings (ReportSettings): Settings (project name, job name) to be included in the report
+        report_settings (ReportSettings): Settings (project name, job name) to be included in the report
 
     Attributes:
         _remote_address (str): The Agent endpoint
         _capabilities (dict): Additional options to be applied to the driver instance
         _agent_session (AgentSession): stores properties of the current agent session
         _token (str): The development token used to authenticate with the Agent
-        _reportsettings (ReportSettings): Settings (project name, job name) to be included in the report
+        _report_settings (ReportSettings): Settings (project name, job name) to be included in the report
         _queue (queue.Queue): queue holding reports to be sent to Agent in separate thread
     """
 
@@ -75,12 +75,12 @@ class AgentClient:
     # Class variable containing the current known Agent version
     __agent_version: str = None
 
-    def __init__(self, token: str, capabilities: dict, reportsettings: ReportSettings):
+    def __init__(self, token: str, capabilities: dict, report_settings: ReportSettings):
         self._remote_address = ConfigHelper.get_agent_service_address()
         self._capabilities = capabilities
         self._agent_session = None
         self._token = token
-        self._reportsettings = reportsettings
+        self._report_settings = report_settings
         self._queue = queue.Queue()
 
         self._running = True
@@ -145,7 +145,7 @@ class AgentClient:
         Returns:
             SessionResponse: object containing the response to the session request
         """
-        session_request = SessionRequest(self._capabilities, self._reportsettings)
+        session_request = SessionRequest(self._capabilities, self._report_settings)
 
         logging.info(f"Session request: {session_request.to_json()}")
 

--- a/src/testproject/sdk/internal/helpers/reporting_command_executor.py
+++ b/src/testproject/sdk/internal/helpers/reporting_command_executor.py
@@ -121,6 +121,16 @@ class ReportingCommandExecutor:
     def settings(self, value: StepSettings):
         self._settings = value
 
+    @property
+    def test_name(self) -> str:
+        """Getter for the latest known test name"""
+        return self._latest_known_test_name
+
+    @test_name.setter
+    def test_name(self, new_name: str):
+        """Setter for the latest known test name"""
+        self._latest_known_test_name = new_name
+
     def _report_command(self, command: str, params: dict, result: dict, passed: bool):
         """Reports a driver command to the TestProject platform
 


### PR DESCRIPTION
**Previously** the decorator would just set the report settings as ENV variables, but that wouldn't work in all cases (Assuming it was tested before and worked for some cases).

**Now** the decorator will not only set the ENV variables, it will also explicitly change the attributes needed for the report to be reported with the intended functionality.
