### PR TITLE
Report decorator fixes

### DIFF
--- a/src/testproject/decorator/report.py
+++ b/src/testproject/decorator/report.py
@@ -14,8 +14,11 @@
 
 import functools
 import os
+from typing import Union
 
 from src.testproject.enums import EnvironmentVariable
+from src.testproject.sdk.drivers.webdriver import Remote
+from src.testproject.sdk.drivers.webdriver.base import BaseDriver
 
 
 def report(project: str = None, job: str = None, test: str = None):
@@ -31,12 +34,15 @@ def report(project: str = None, job: str = None, test: str = None):
     def report_decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            if project is not None:
+            driver: Union[Remote, BaseDriver] = kwargs.get('driver')
+            if project:
                 os.environ[EnvironmentVariable.TP_PROJECT_NAME.value] = project
-            if job is not None:
+            if job:
                 os.environ[EnvironmentVariable.TP_JOB_NAME.value] = job
-            if test is not None:
+            if test:
                 os.environ[EnvironmentVariable.TP_TEST_NAME.value] = test
+                if driver:
+                    driver.command_executor.test_name = test
             return func(*args, **kwargs)
 
         return wrapper

--- a/src/testproject/decorator/report.py
+++ b/src/testproject/decorator/report.py
@@ -13,13 +13,9 @@
 # limitations under the License.
 
 import functools
-import logging
 import os
-from typing import Union
 
 from src.testproject.enums import EnvironmentVariable
-from src.testproject.sdk.drivers.webdriver import Remote
-from src.testproject.sdk.drivers.webdriver.base import BaseDriver
 
 
 def report(project: str = None, job: str = None, test: str = None):
@@ -35,24 +31,12 @@ def report(project: str = None, job: str = None, test: str = None):
     def report_decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            driver: Union[Remote, BaseDriver] = kwargs.get('driver')
-            if project:
+            if project is not None:
                 os.environ[EnvironmentVariable.TP_PROJECT_NAME.value] = project
-            if job:
+            if job is not None:
                 os.environ[EnvironmentVariable.TP_JOB_NAME.value] = job
-            if test:
+            if test is not None:
                 os.environ[EnvironmentVariable.TP_TEST_NAME.value] = test
-            # Setting the report settings directly to the driver.
-            if driver:
-                try:
-                    if project:
-                        driver.command_executor.agent_client.report_settings.project_name = project
-                    if job:
-                        driver.command_executor.agent_client.report_settings.job_name = job
-                    if test:
-                        driver.command_executor.test_name = test
-                except AttributeError as e:
-                    logging.error("Failed to update report settings.", exc_info=e)
             return func(*args, **kwargs)
 
         return wrapper

--- a/src/testproject/rest/reportsettings.py
+++ b/src/testproject/rest/reportsettings.py
@@ -34,20 +34,10 @@ class ReportSettings:
         """Getter for the project name"""
         return self._project_name
 
-    @project_name.setter
-    def project_name(self, new_name: str):
-        """Setter for the project name"""
-        self._project_name = new_name
-
     @property
     def job_name(self) -> str:
         """Getter for the job name"""
         return self._job_name
-
-    @job_name.setter
-    def job_name(self, new_name: str):
-        """Setter for the job name"""
-        self._job_name = new_name
 
     def __eq__(self, other):
         """Custom equality function"""

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -98,11 +98,6 @@ class AgentClient:
         """Getter for the Agent session object"""
         return self._agent_session
 
-    @property
-    def report_settings(self) -> ReportSettings:
-        """Getter for the Report settings object."""
-        return self._report_settings
-
     def __start_session(self) -> bool:
         """Starts a new development session with the Agent
 

--- a/tests/internal/report_decorator_test.py
+++ b/tests/internal/report_decorator_test.py
@@ -1,0 +1,21 @@
+import pytest
+
+from src.testproject.decorator import report
+from src.testproject.sdk.drivers import webdriver
+
+DEV_TOKEN = "Hnw-B_FakRKt5Nar7jICIbHNTwBNW9Pp09MH_nXZTI41"
+
+
+@pytest.fixture
+def driver():
+    def _driver():
+        return webdriver.Chrome(token=DEV_TOKEN, projectname="Report Decorator Project", jobname="Report Decorator Job")
+    driver = _driver()
+    yield driver
+    driver.quit()
+
+
+# MAIN TEST #
+@report(test="Report Decorator Test")
+def test_report_decorator(driver):
+    driver.get(url='https://www.google.com')


### PR DESCRIPTION
- Added unit-test for internal use to test the report decorator's uploaded reports.
- Reverted previous change since it didn't help with the [issue](https://github.com/testproject-io/python-sdk/issues/48) the user was complaining about.
However I've added the option to set test name even when using pytest.fixture.