### PR TITLE
Improving step reports for Addon execution and WebDriverWait commands executions.

### DIFF
--- a/src/testproject/classes/step_settings.py
+++ b/src/testproject/classes/step_settings.py
@@ -18,10 +18,11 @@ from src.testproject.enums import SleepTimingType, TakeScreenshotConditionType
 class StepSettings:
     """Represents settings for automatic step reporting."""
     def __init__(self, sleep_time: int = 0, sleep_timing_type: SleepTimingType = None, timeout: int = -1,
-                 invert_result: bool = False,
+                 invert_result: bool = False, always_pass: bool = False,
                  screenshot_condition: TakeScreenshotConditionType = TakeScreenshotConditionType.Failure):
         self.sleep_time = sleep_time
         self.sleep_timing_type = sleep_timing_type
         self.timeout = timeout
+        self.always_pass = always_pass
         self.invert_result = invert_result
         self.screenshot_condition = screenshot_condition

--- a/src/testproject/classes/web_driver_wait.py
+++ b/src/testproject/classes/web_driver_wait.py
@@ -22,6 +22,7 @@ class TestProjectWebDriverWait(WebDriverWait):
     """
     def __init__(self, driver: Union[BaseDriver, Remote], timeout):
         super().__init__(driver, timeout)
+        self._driver = driver
 
     def until(self, method, message=''):
         """Executes the wrapping function for until."""
@@ -108,3 +109,8 @@ class TestProjectWebDriverWait(WebDriverWait):
                 continue
             res += [attr]
         return res
+
+    @property
+    def driver(self):
+        """Getter for the driver."""
+        return self._driver

--- a/src/testproject/classes/web_driver_wait.py
+++ b/src/testproject/classes/web_driver_wait.py
@@ -2,6 +2,7 @@ import os
 import json
 from typing import Union
 
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.wait import WebDriverWait
 
 from src.testproject.classes import DriverStepSettings, StepSettings
@@ -21,9 +22,6 @@ class TestProjectWebDriverWait(WebDriverWait):
     """
     def __init__(self, driver: Union[BaseDriver, Remote], timeout):
         super().__init__(driver, timeout)
-        self.step_helper = driver.command_executor.step_helper
-        self.step_settings = driver.command_executor.settings
-        self.session_id = driver.command_executor.agent_client.agent_session.session_id
 
     def until(self, method, message=''):
         """Executes the wrapping function for until."""
@@ -41,53 +39,63 @@ class TestProjectWebDriverWait(WebDriverWait):
         Based on the function's result and given method, it will report this Step with all the needed information.
         Returns the result of the executed function.
         """
+        timeout_exception = None
+        step_helper = self.driver.command_executor.step_helper
+        step_settings = self.driver.command_executor.settings
         # Disable reports
         self._driver.report().disable_reports(True)
+        # Handle driver timeout
+        step_helper.handle_timeout(timeout=step_settings.timeout)
+        # Handle sleep before
+        step_helper.handle_sleep(sleep_timing_type=step_settings.sleep_timing_type,
+                                 sleep_time=step_settings.sleep_time)
+        # Execute the function with default StepSettings.
         with DriverStepSettings(self._driver, StepSettings()):
-            # Handle driver timeout
-            self.step_helper.handle_timeout(timeout=self.step_settings.timeout)
-            # Handle sleep before
-            self.step_helper.handle_sleep(sleep_timing_type=self.step_settings.sleep_timing_type,
-                                          sleep_time=self.step_settings.sleep_time)
-            # Execute the function.
-            result = getattr(super(), function_name)(method, message)
-            # Handle sleep after
-            self.step_helper.handle_sleep(sleep_timing_type=self.step_settings.sleep_timing_type,
-                                          sleep_time=self.step_settings.sleep_time, step_executed=True)
-            # Handle invert result
-            result = not result if self.step_settings.invert_result else result
-
-            # Handle always pass
-            result = True if self.step_settings.always_pass else result
-
-            # Handle screenshot condition
-            screenshot = self.step_helper.take_screenshot(self.step_settings.screenshot_condition, result)
+            try:
+                result = getattr(super(), function_name)(method, message)
+            except TimeoutException as e:
+                result = False
+                timeout_exception = e
+        # Handle sleep after
+        step_helper.handle_sleep(sleep_timing_type=step_settings.sleep_timing_type,
+                                 sleep_time=step_settings.sleep_time, step_executed=True)
+        # Handle result
+        result, step_message = step_helper.handle_step_result(step_result=result,
+                                                              invert_result=step_settings.invert_result,
+                                                              always_pass=step_settings.always_pass)
+        # Handle screenshot condition
+        screenshot = step_helper.take_screenshot(step_settings.screenshot_condition, result)
 
         # Enable reports and report the step result with all execution details.
         self._driver.report().disable_reports(False)
-        result_str = (('Passed' if result else 'Failed')
-                      + (' - Step result inverted' if self.step_settings.invert_result else ''))
-        step_name, step_attributes = self.get_report_details(method)
+
+        # Inferring function name - until / until not
         function_name = ' '.join(function_name.split('_'))
+        # Getting all additional step information.
+        step_name, step_attributes = self.get_report_details(method)
         self._driver.report().step(description=f'Wait {function_name} {step_name}',
-                                   message=f'Step {result_str}{os.linesep}.'
-                                           f'Step attributes:{os.linesep}'
-                                           f'{step_attributes}',
+                                   message=f'{step_message}{os.linesep}',
                                    passed=result,
+                                   inputs=step_attributes,
                                    screenshot=screenshot)
+        # Always pass ignore result and thrown exception.
+        if step_settings.always_pass:
+            return True
+        # Raise exception if there was one.
+        if timeout_exception:
+            raise timeout_exception
         return result
 
     def get_report_details(self, method):
         """Returns the inferred report details.
 
         Step name is the method class's name, underscores are replaces with spaces.
-        Step attributes is all the method's attributes and their values.
+        Attributes dict is all the method's attributes and their values.
         """
         step_name = ' '.join(method.__class__.__name__.split('_'))
         attributes_dict = {attribute: json.dumps(getattr(method, attribute))
                            for attribute in self.get_user_attributes(method)}
-        step_attributes = json.dumps(attributes_dict, indent=4)
-        return step_name, step_attributes
+        return step_name, attributes_dict
 
     @staticmethod
     def get_user_attributes(cls, exclude_methods=True):

--- a/src/testproject/classes/web_driver_wait.py
+++ b/src/testproject/classes/web_driver_wait.py
@@ -57,8 +57,12 @@ class TestProjectWebDriverWait(WebDriverWait):
             # Handle invert result
             result = not result if self.step_settings.invert_result else result
 
+            # Handle always pass
+            result = True if self.step_settings.always_pass else result
+
             # Handle screenshot condition
             screenshot = self.step_helper.take_screenshot(self.step_settings.screenshot_condition, result)
+
         # Enable reports and report the step result with all execution details.
         self._driver.report().disable_reports(False)
         result_str = (('Passed' if result else 'Failed')

--- a/src/testproject/helpers/addonhelper.py
+++ b/src/testproject/helpers/addonhelper.py
@@ -82,4 +82,7 @@ class AddonHelper:
                                               if response.execution_result_type is not ExecutionResultType.Passed
                                               else ExecutionResultType.Failed)
 
+
+        # Handle always pass
+        result = True if settings.always_pass else result
         return action

--- a/src/testproject/helpers/step_helper.py
+++ b/src/testproject/helpers/step_helper.py
@@ -38,7 +38,7 @@ class StepHelper:
                 self.executor.execute(Command.IMPLICIT_WAIT, {'sessionId': self.session_id, 'ms': float(timeout)})
 
     @staticmethod
-    def handle_sleep(sleep_timing_type, sleep_time, command, step_executed=False):
+    def handle_sleep(sleep_timing_type, sleep_time, command=None, step_executed=False):
         """Handles step sleep before/after step execution."""
         # Sleep Before if not Quit command
         if command is not Command.QUIT:

--- a/src/testproject/helpers/step_helper.py
+++ b/src/testproject/helpers/step_helper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
 from time import sleep
 
 from selenium.webdriver.remote.command import Command
@@ -60,3 +61,28 @@ class StepHelper:
         if not passed and (take_screenshot_condition is TakeScreenshotConditionType.Failure):
             return False
         return False
+
+    @staticmethod
+    def handle_step_result(step_result: bool, base_msg: str = None, invert_result: bool = False,
+                           always_pass: bool = False) -> tuple:
+        """Handles the step result.
+
+        Returns a tuple of the changed result and a formatted step message for reporting.
+        """
+        result_str, result_opposite_str = ('Passed', 'Failed') if step_result else ('Failed', 'Passed')
+        invert_msg = f'Step result {result_str} inverted to {result_opposite_str}.{os.linesep}' if invert_result else ''
+        failure_behavior_msg = (f'Failure behaviour \'Always Pass\' is configured,'
+                                f' step result is forcibly set as Passed.{os.linesep}'
+                                if always_pass else '')
+        # Create a base message if none was provided.
+        base_msg = base_msg if base_msg else f'Step {result_str}.'
+        # Add a line break to the base message.
+        base_msg = base_msg if base_msg.endswith(os.linesep) else base_msg + os.linesep
+
+        # Handle invert result
+        step_result = not step_result if invert_result else step_result
+
+        # Handle always pass
+        step_result = True if always_pass else step_result
+
+        return step_result, f'{base_msg}{invert_msg}{failure_behavior_msg}'

--- a/src/testproject/rest/messages/stepreport.py
+++ b/src/testproject/rest/messages/stepreport.py
@@ -14,6 +14,8 @@
 
 import uuid
 
+from src.testproject.classes import ElementSearchCriteria
+
 
 class StepReport:
     """Payload object sent to the Agent when reporting a test step.
@@ -23,19 +25,29 @@ class StepReport:
             message (str): A message that goes with the step
             passed (bool): True if the step should be marked as passed, False otherwise
             screenshot (str): A base64 encoded screenshot that is associated with the step
+            element (ElementSearchCriteria): The step's element search criteria.
+            inputs (dict): Dictionary of step input parameters - name:value
+            outputs (dict): Dictionary of step output parameters - name:value
 
         Attributes:
             _description (str): The step description
             _message (str): A message that goes with the step
             _passed (bool): True if the step should be marked as passed, False otherwise
             _screenshot (str): A base64 encoded screenshot that is associated with the step
+            _element (dict): The step's element search criteria in JSON representation.
+            _input_params (dict): Dictionary of step input parameters - name:value
+            _output_params (dict): Dictionary of step output parameters - name:value
     """
 
-    def __init__(self, description: str, message: str, passed: bool, screenshot: str = None):
+    def __init__(self, description: str, message: str, passed: bool, screenshot: str = None,
+                 element: ElementSearchCriteria = None, inputs: dict = None, outputs: dict = None):
         self._description = description
         self._message = message
         self._passed = passed
         self._screenshot = screenshot
+        self._element = element.to_json() if element else None
+        self._input_params = inputs
+        self._output_params = outputs
 
     def to_json(self) -> dict:
         """Generates a dict containing the JSON representation of the step payload"""
@@ -44,6 +56,9 @@ class StepReport:
             "description": self._description,
             "message": self._message,
             "passed": self._passed,
+            "element": self._element,
+            "inputParameters": self._input_params,
+            "outputParameters": self._output_params
         }
         if self._screenshot is not None:
             json["screenshot"] = self._screenshot

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -32,8 +32,8 @@ class BaseDriver(RemoteWebDriver):
     Args:
         capabilities (dict): Automation session desired capabilities and options
         token (str): Developer token to be used to communicate with the Agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
 
     Attributes:
@@ -51,8 +51,8 @@ class BaseDriver(RemoteWebDriver):
         self,
         capabilities: dict,
         token: str,
-        projectname: str,
-        jobname: str,
+        project_name: str,
+        job_name: str,
         disable_reports: bool,
     ):
 
@@ -68,22 +68,22 @@ class BaseDriver(RemoteWebDriver):
 
         if disable_reports:
             # Setting the project and job name to empty strings will cause the Agent to not initialize a report
-            self._projectname = ""
-            self._jobname = ""
+            self._project_name = ""
+            self._job_name = ""
         else:
-            self._projectname = (
-                projectname
-                if projectname is not None
+            self._project_name = (
+                project_name
+                if project_name is not None
                 else ReportHelper.infer_project_name()
             )
-            self._jobname = (
-                jobname if jobname is not None else ReportHelper.infer_job_name()
+            self._job_name = (
+                job_name if job_name is not None else ReportHelper.infer_job_name()
             )
 
         self._agent_client: AgentClient = AgentClient(
             token=self._token,
             capabilities=capabilities,
-            report_settings=ReportSettings(self._projectname, self._jobname),
+            report_settings=ReportSettings(self._project_name, self._job_name),
         )
         self._agent_session: AgentSession = self._agent_client.agent_session
         self.w3c = True if self._agent_session.dialect == "W3C" else False

--- a/src/testproject/sdk/drivers/webdriver/chrome.py
+++ b/src/testproject/sdk/drivers/webdriver/chrome.py
@@ -23,8 +23,8 @@ class Chrome(BaseDriver):
         chrome_options (ChromeOptions): Chrome automation session desired capabilities and options
         desired_capabilities (dict): Dictionary object containing desired capabilities for Chrome automation session
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -33,8 +33,8 @@ class Chrome(BaseDriver):
         chrome_options: ChromeOptions = None,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         # If no options or capabilities are specified at all, use default ChromeOptions
@@ -51,7 +51,7 @@ class Chrome(BaseDriver):
         super().__init__(
             capabilities=caps,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/drivers/webdriver/edge.py
+++ b/src/testproject/sdk/drivers/webdriver/edge.py
@@ -23,8 +23,8 @@ class Edge(BaseDriver):
         edge_options (Options): Edge automation session desired capabilities and options
         desired_capabilities (dict): Dictionary object containing desired capabilities for Chrome automation session
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -33,8 +33,8 @@ class Edge(BaseDriver):
         edge_options: Options = None,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         # If no options or capabilities are specified at all, use default Options
@@ -51,7 +51,7 @@ class Edge(BaseDriver):
         super().__init__(
             capabilities=caps,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/drivers/webdriver/firefox.py
+++ b/src/testproject/sdk/drivers/webdriver/firefox.py
@@ -23,8 +23,8 @@ class Firefox(BaseDriver):
         firefox_options (FirefoxOptions): Edge automation session desired capabilities and options
         desired_capabilities (dict): Dictionary object containing desired capabilities for Firefox automation session
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -33,8 +33,8 @@ class Firefox(BaseDriver):
         firefox_options: FirefoxOptions = None,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         # If no options or capabilities are specified at all, use default FirefoxOptions
@@ -51,7 +51,7 @@ class Firefox(BaseDriver):
         super().__init__(
             capabilities=caps,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/drivers/webdriver/ie.py
+++ b/src/testproject/sdk/drivers/webdriver/ie.py
@@ -23,8 +23,8 @@ class Ie(BaseDriver):
         ie_options (Options): IE automation session desired capabilities and options
         desired_capabilities (dict): Dictionary object containing desired capabilities for IE automation session
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -33,8 +33,8 @@ class Ie(BaseDriver):
         ie_options: Options = None,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         # If no options or capabilities are specified at all, use default Options
@@ -51,7 +51,7 @@ class Ie(BaseDriver):
         super().__init__(
             capabilities=caps,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/drivers/webdriver/safari.py
+++ b/src/testproject/sdk/drivers/webdriver/safari.py
@@ -22,8 +22,8 @@ class Safari(BaseDriver):
     Args:
         desired_capabilities (dict): Safari automation session desired capabilities and options
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -31,14 +31,14 @@ class Safari(BaseDriver):
         self,
         desired_capabilities: dict = DesiredCapabilities.SAFARI,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         super().__init__(
             capabilities=desired_capabilities,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -390,6 +390,7 @@ class AgentClient:
             "POST",
             urljoin(self._remote_address, Endpoint.AddonExecution.value),
             self._create_action_proxy_payload(action),
+            {"skipReporting": "true"}  # Skip local reporting (done by the SDK).
         )
 
         if operation_result.status_code == HTTPStatus.NOT_FOUND:

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -191,18 +191,21 @@ class AgentClient:
         )
         return start_session_response
 
-    def send_request(self, method, path, body=None) -> OperationResult:
+    def send_request(self, method, path, body=None, params=None) -> OperationResult:
         """Sends HTTP request to Agent
 
         Args:
             method (str): HTTP method (GET, POST, ...)
             path (str): Relative API route path
             body (dict): Request body
+            params (dict): Request parameters
 
         Returns:
             OperationResult: contains result of the sent request
         """
         with requests.Session() as session:
+            if params:
+                session.params = params
             if method == "GET":
                 response = session.get(path, headers={"Authorization": self._token})
             elif method == "POST":

--- a/src/testproject/sdk/internal/helpers/reporting_command_executor.py
+++ b/src/testproject/sdk/internal/helpers/reporting_command_executor.py
@@ -169,6 +169,9 @@ class ReportingCommandExecutor:
         # Invert result is set?
         passed = not passed if self.settings.invert_result else passed
 
+        # Handle always pass
+        passed = True if self.settings.always_pass else passed
+
         driver_command_report = DriverCommandReport(command, params, result, passed)
 
         # Is screenshot needed?

--- a/src/testproject/sdk/internal/reporter/reporter.py
+++ b/src/testproject/sdk/internal/reporter/reporter.py
@@ -15,6 +15,7 @@
 import logging
 import os
 
+from src.testproject.classes import ElementSearchCriteria
 from src.testproject.helpers import ReportHelper
 from src.testproject.rest.messages import StepReport, CustomTestReport
 
@@ -33,7 +34,8 @@ class Reporter:
         self._command_executor = command_executor
 
     def step(
-        self, description: str, message: str, passed: bool, screenshot: bool = False
+        self, description: str, message: str, passed: bool, screenshot: bool = False,
+            element: ElementSearchCriteria = None, inputs: dict = None, outputs: dict = None
     ):
         """Sends a step report to the Agent Client
 
@@ -42,6 +44,9 @@ class Reporter:
             message (str): A message that goes with the step
             passed (bool): True if the step should be marked as passed, False otherwise
             screenshot (bool): True if a screenshot should be made, False otherwise
+            element (ElementSearchCriteria): The step's element search criteria.
+            inputs (dict): Input parameters associated with the step
+            outputs (dict): Output parameters associated with the step
         """
 
         # First update the current test name and report a test if necessary
@@ -54,6 +59,9 @@ class Reporter:
                 message,
                 passed,
                 self._command_executor.create_screenshot() if screenshot else None,
+                element,
+                inputs,
+                outputs,
             )
             self._command_executor.agent_client.report_step(step_report)
         else:

--- a/tests/ci/headless/chrome_addon_proxy_test.py
+++ b/tests/ci/headless/chrome_addon_proxy_test.py
@@ -25,7 +25,7 @@ from selenium.webdriver import ChromeOptions
 def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/chrome_basic_test.py
+++ b/tests/ci/headless/chrome_basic_test.py
@@ -23,7 +23,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/chrome_multiple_test.py
+++ b/tests/ci/headless/chrome_multiple_test.py
@@ -28,7 +28,7 @@ if version.parse(ConfigHelper.get_sdk_version()) < version.parse("0.64.0"):
 def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/chrome_no_options_or_caps_test.py
+++ b/tests/ci/headless/chrome_no_options_or_caps_test.py
@@ -20,7 +20,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(projectname="CI - Python")
+    driver = webdriver.Chrome(project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/chrome_step_settings_test.py
+++ b/tests/ci/headless/chrome_step_settings_test.py
@@ -26,7 +26,7 @@ from tests.pageobjects.web import LoginPage
 def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/cloud_basic_test.py
+++ b/tests/ci/headless/cloud_basic_test.py
@@ -25,7 +25,7 @@ def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
     chrome_options.set_capability("cloud:URL", os.getenv("TP_CLOUD_URL"))
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/firefox_basic_test.py
+++ b/tests/ci/headless/firefox_basic_test.py
@@ -24,7 +24,7 @@ def driver():
     firefox_options = Options()
     firefox_options.add_argument("-headless")
     driver = webdriver.Firefox(
-        firefox_options=firefox_options, projectname="CI - Python"
+        firefox_options=firefox_options, project_name="CI - Python"
     )
     yield driver
     driver.quit()

--- a/tests/examples/drivers/web/chrome_driver_test.py
+++ b/tests/examples/drivers/web/chrome_driver_test.py
@@ -21,7 +21,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(chrome_options=ChromeOptions(), projectname="Examples", jobname=None)
+    driver = webdriver.Chrome(chrome_options=ChromeOptions(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/drivers/web/edge_driver_test.py
+++ b/tests/examples/drivers/web/edge_driver_test.py
@@ -21,7 +21,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Edge(edge_options=Options(), projectname="Examples", jobname=None)
+    driver = webdriver.Edge(edge_options=Options(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/drivers/web/firefox_driver_test.py
+++ b/tests/examples/drivers/web/firefox_driver_test.py
@@ -21,7 +21,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Firefox(firefox_options=Options(), projectname="Examples", jobname=None)
+    driver = webdriver.Firefox(firefox_options=Options(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/drivers/web/ie_driver_test.py
+++ b/tests/examples/drivers/web/ie_driver_test.py
@@ -21,7 +21,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Ie(ie_options=Options(), projectname="Examples", jobname=None)
+    driver = webdriver.Ie(ie_options=Options(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/drivers/web/safari_driver_test.py
+++ b/tests/examples/drivers/web/safari_driver_test.py
@@ -20,7 +20,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Safari(projectname="Examples", jobname=None)
+    driver = webdriver.Safari(project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/reports/report_failed_pytest_assertion_test.py
+++ b/tests/examples/reports/report_failed_pytest_assertion_test.py
@@ -22,7 +22,7 @@ from tests.pageobjects.web import LoginPage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(chrome_options=ChromeOptions(), projectname="Examples", jobname=None)
+    driver = webdriver.Chrome(chrome_options=ChromeOptions(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/reports/report_failed_unittest_assertion_test.py
+++ b/tests/examples/reports/report_failed_unittest_assertion_test.py
@@ -23,7 +23,7 @@ from tests.pageobjects.web import LoginPage
 class TestBasic(unittest.TestCase):
     def setUp(self):
         self.driver = webdriver.Chrome(
-            chrome_options=ChromeOptions(), projectname="Examples", jobname=None
+            chrome_options=ChromeOptions(), project_name="Examples", job_name=None
         )
 
     @report_assertion_errors

--- a/tests/internal/addon_invert_result_test.py
+++ b/tests/internal/addon_invert_result_test.py
@@ -11,8 +11,8 @@ DEV_TOKEN = "kjvgLv5jxNuy5g48Nd2BMrOFG-kGdaZ86goeBjhsqts1"
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(token=DEV_TOKEN, projectname="Addon Invert Result Project",
-                              jobname="Addon Invert Result Job")
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Addon Invert Result Project",
+                              job_name="Addon Invert Result Job")
     yield driver
     driver.quit()
 

--- a/tests/internal/addon_invert_result_test.py
+++ b/tests/internal/addon_invert_result_test.py
@@ -4,6 +4,7 @@ from selenium.webdriver.common.by import By
 from proxy_examples.actions import TypeRandomPhoneAction
 from src.testproject.classes import DriverStepSettings, StepSettings
 from src.testproject.decorator import report
+from src.testproject.enums import TakeScreenshotConditionType
 from src.testproject.sdk.drivers import webdriver
 
 DEV_TOKEN = "kjvgLv5jxNuy5g48Nd2BMrOFG-kGdaZ86goeBjhsqts1"
@@ -29,5 +30,10 @@ def test_report_decorator(driver):
     # The TypeRandomPhoneAction addon generates a unique phone number
     # and types that in the specified textfield
     # Inverting result using the StepSettings.
-    with DriverStepSettings(driver, StepSettings(invert_result=True)):
+    with DriverStepSettings(driver, StepSettings(invert_result=True,
+                                                 screenshot_condition=TakeScreenshotConditionType.Failure,
+                                                 always_pass=True)):
+        driver.addons().execute(TypeRandomPhoneAction("1", 10), *textfield_phone)
+    with DriverStepSettings(driver, StepSettings(invert_result=True,
+                                                 screenshot_condition=TakeScreenshotConditionType.Failure)):
         driver.addons().execute(TypeRandomPhoneAction("1", 10), *textfield_phone)

--- a/tests/internal/report_decorator_test.py
+++ b/tests/internal/report_decorator_test.py
@@ -8,7 +8,7 @@ DEV_TOKEN = "Hnw-B_FakRKt5Nar7jICIbHNTwBNW9Pp09MH_nXZTI41"
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(token=DEV_TOKEN, projectname="Report Decorator Project", jobname="Report Decorator Job")
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Report Decorator Project", job_name="Report Decorator Job")
     yield driver
     driver.quit()
 

--- a/tests/internal/web_driver_wait_test.py
+++ b/tests/internal/web_driver_wait_test.py
@@ -1,0 +1,47 @@
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from src.testproject.classes import DriverStepSettings, StepSettings, WebDriverWait
+from src.testproject.enums import TakeScreenshotConditionType
+from src.testproject.sdk.drivers import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as ec
+
+DEV_TOKEN = "ZNXf2v22_eXli4w4UsLM5ulkfxLHK1IqNSfHH7i2wyI1"
+
+
+@pytest.fixture
+def browser():
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Web Driver Report Project",
+                              job_name="Web Driver Report Job")
+    yield driver
+    driver.quit()
+
+
+@pytest.fixture()
+def wait(browser):
+    wait = WebDriverWait(browser, 2)
+    yield wait
+
+
+def test_wait_with_ec_invisible(browser, wait):
+    # Case 1 - Should report passed.
+    browser.get('http://www.google.com')
+    search_field = (By.CSS_SELECTOR, "input[name='z']")  # => z should be q, thus simulating a non-present element
+    element_not_present = wait.until(ec.invisibility_of_element_located(search_field))
+    assert element_not_present
+    # Case 2 - Should report failed.
+    try:
+        wait.until(ec.title_is("Title that is definitely not this one."))
+    except TimeoutException:
+        pass
+    # Case 3 - Report with StepSettings
+    # Inverting result and taking picture on success.
+    # Wait should timeout and report fail which will be inverted to passed and include picture.
+    with DriverStepSettings(driver=wait.driver,
+                            step_settings=StepSettings(invert_result=True,
+                                                       screenshot_condition=TakeScreenshotConditionType.Failure)):
+        try:
+            wait.until_not(ec.url_contains("google"))
+        except TimeoutException:
+            pass


### PR DESCRIPTION
This PR is a continuation of #113.

**Added**

- New StepReport attribute 'always_pass', when True is passed the step will always be reported and return a result of True.
- Addons now handle driver StepReports. (invert result, screeshot behavior and so on...)
- Executing proxy/addon is now being reported by the SDK instead of by the Agent.

**Improved**

- Renamed attribute names of BaseDriver and Remote to be readable with underscores (notreadable -> not_readable)
- Reports generated by our WebDriverWait and Addon executions now include input/output parameters and the element search criteria when provided.
