### PR TITLE
Improved reporting (addons and driver commands) and implementing SDK's WebDriverWait class.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.65.1] - 2021-01-19
+
+### Added
+
+- ([#50](https://github.com/testproject-io/python-sdk/issues/50)) - 
+  Internal WebDriverWait class with automatic reporting.
+- New driver action 'pause' - pause the execution for a given time.
+- Manual step reporting can now include the step's input/output parameters as well as the element the step used.
+    - Input/Output parameters attribute expects a Dict[str, object]
+    - Element attribute expects an [ElementSearchCriteria](https://github.com/testproject-io/python-sdk/blob/master/src/testproject/classes/elementsearchcriteria.py) object
+  
+### Changed
+
+- Attributes 'projectname' and 'jobname' that are used when creating driver instance have been renamed to
+  'project_name' and 'job_name'.
+  
+### Fixed
+
+- Proxy/Addon executions properly handles driver step settings (sleep, invert result, screenshots, etc'...)
+
 ## [0.65.0] - 2021-01-06
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,12 @@ The examples shown in this document are based on Chrome. The SDK works in the sa
 * iOS apps (using Appium)
 * Generic driver (for non-UI tests)
 
+WebDriverWait
+-------------
+In order to use Selenium's WebDriverWait with TestProject SDK all you need to do is import it directly from the SDK classes instead of from selenium's libraries.
+
+An example can be seen `here <https://github.com/testproject-io/python-sdk/blob/master/tests/examples/web_driver_wait/web_driver_wait_test.py>`__.
+
 Development token
 -----------------
 The SDK uses a development token for communication with the Agent and the TestProject platform.
@@ -261,7 +267,9 @@ If this feature is disabled, or you would like to add steps manually, you can us
     def test_report_step_manually():
         driver = webdriver.Chrome()
         # Your test code goes here
-        driver.report().step(description='My step description', message='An additional message', passed=False, screenshot=True)
+        driver.report().step(description='My step description', message='An additional message', passed=False,
+                             screenshot=True, element=element_search_criteria_object, inputs=dict_of_input_parameters,
+                             outputs=dict_of_output_parameters)
         driver.quit()
 
 Here is a complete example using `manual test reporting of tests and steps <https://github.com/testproject-io/python-sdk/blob/master/tests/examples/reports/manual_reporting_test.py>`__.

--- a/src/testproject/classes/__init__.py
+++ b/src/testproject/classes/__init__.py
@@ -3,6 +3,7 @@ from .elementsearchcriteria import ElementSearchCriteria
 from .proxydescriptor import ProxyDescriptor
 from .step_settings import StepSettings
 from .driver_step_settings import DriverStepSettings
+from .web_driver_wait import TestProjectWebDriverWait as WebDriverWait
 
 __all__ = ["ActionExecutionResponse", "ElementSearchCriteria", "ProxyDescriptor", "StepSettings",
-           "DriverStepSettings"]
+           "DriverStepSettings", "WebDriverWait"]

--- a/src/testproject/classes/driver_step_settings.py
+++ b/src/testproject/classes/driver_step_settings.py
@@ -21,6 +21,16 @@ class DriverStepSettings:
 
     If driver auto step reports is enabled, all the driver commands within this compound statement will be reported
     according to the given StepSettings.
+
+    Args:
+        driver (Union[BaseDriver, Remote]): the driver instance to apply the StepSettings to.
+        step_settings: is the StepSettings object to apply on the driver.
+
+    Examples:
+        # Assuming driver instance 'driver' and StepSettings instance step_settings
+        with DriverStepSettings(driver, step_settings):
+            # Some driver command.
+
     """
     def __init__(self, driver, step_settings: StepSettings):
         """Initializes the 'with' statement."""

--- a/src/testproject/classes/step_settings.py
+++ b/src/testproject/classes/step_settings.py
@@ -16,7 +16,24 @@ from src.testproject.enums import SleepTimingType, TakeScreenshotConditionType
 
 
 class StepSettings:
-    """Represents settings for automatic step reporting."""
+    """Represents settings for automatic step reporting.
+
+    Args:
+        sleep_time: is the sleep time number in milliseconds.
+        sleep_timing_type: defines if the sleep will occur 'Before' or 'After' step execution.
+        timeout: of the driver AKA explicit wait.
+        invert_result: will invert step execution result when True.
+        always_pass: will forcefully pass the step in case of failure when True.
+
+    Examples:
+        # This class should be used with a driver.
+        # Option 1 - assuming driver instance 'driver'
+        driver.step_settings = StepSettings(**args)
+        # Option 2 - using the DriverStepSettings
+        with DriverStepSettings(driver, StepSettings(**args)):
+            # Some driver command.
+
+    """
     def __init__(self, sleep_time: int = 0, sleep_timing_type: SleepTimingType = None, timeout: int = -1,
                  invert_result: bool = False, always_pass: bool = False,
                  screenshot_condition: TakeScreenshotConditionType = TakeScreenshotConditionType.Failure):

--- a/src/testproject/classes/step_settings.py
+++ b/src/testproject/classes/step_settings.py
@@ -18,10 +18,11 @@ from src.testproject.enums import SleepTimingType, TakeScreenshotConditionType
 class StepSettings:
     """Represents settings for automatic step reporting."""
     def __init__(self, sleep_time: int = 0, sleep_timing_type: SleepTimingType = None, timeout: int = -1,
-                 invert_result: bool = False,
+                 invert_result: bool = False, always_pass: bool = False,
                  screenshot_condition: TakeScreenshotConditionType = TakeScreenshotConditionType.Failure):
         self.sleep_time = sleep_time
         self.sleep_timing_type = sleep_timing_type
         self.timeout = timeout
+        self.always_pass = always_pass
         self.invert_result = invert_result
         self.screenshot_condition = screenshot_condition

--- a/src/testproject/classes/web_driver_wait.py
+++ b/src/testproject/classes/web_driver_wait.py
@@ -1,0 +1,148 @@
+import os
+import json
+from typing import Union
+
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support.wait import WebDriverWait
+
+from src.testproject.classes import DriverStepSettings, StepSettings
+from src.testproject.sdk.drivers.webdriver import Remote
+from src.testproject.sdk.drivers.webdriver.base import BaseDriver
+
+
+class TestProjectWebDriverWait(WebDriverWait):
+    """Wrapper class for the WebDriverWait.
+
+    WebDriverWait uses until/until_not functions, these functions can call a certain driver command more than once.
+    Moreover, the evaluated step result doesn't have to match the result of the driver command.
+    For Example:
+        until(title_is(title)) will execute driver.title which in itself will work (as a driver command)
+        but that doesnt guarantee that the title is the expected title.
+    Due to the above, this wrapper class handles the step reporting and user defined step settings.
+
+    Args:
+        driver: that this WebDriverWait instance will use to execute commands.
+        timeout: is the WebDriverWait timeout to wait for expected condition before raising TimeoutException.
+
+    """
+    def __init__(self, driver: Union[BaseDriver, Remote], timeout):
+        super().__init__(driver, timeout)
+        self._driver = driver
+
+    def until(self, method, message=''):
+        """Executes the wrapping function for until."""
+        return self.execute("until", method, message)
+
+    def until_not(self, method, message=''):
+        """Executes the wrapping function for until_not."""
+        return self.execute("until_not", method, message)
+
+    def execute(self, function_name, method, message):
+        """Executes the function (until/until_not) silently (without reports/settings).
+
+        This execution will take into account the defined step settings and will handle them only once before silently
+        executing the function.
+        Based on the function's result and given method, it will report this Step with all the needed information.
+        Returns the result of the executed function.
+        """
+        timeout_exception = None
+        step_helper = self.driver.command_executor.step_helper
+        step_settings = self.driver.command_executor.settings
+        # Save current disable_reports value and disable reports before executing the wait function.
+        reports_disabled = self._driver.command_executor.disable_reports
+        self._driver.report().disable_reports(True)
+        # Handle driver timeout
+        step_helper.handle_timeout(timeout=step_settings.timeout)
+        # Handle sleep before
+        step_helper.handle_sleep(sleep_timing_type=step_settings.sleep_timing_type,
+                                 sleep_time=step_settings.sleep_time)
+        # Execute the function with default StepSettings.
+        with DriverStepSettings(self._driver, StepSettings()):
+            try:
+                result = getattr(super(), function_name)(method, message)
+            except TimeoutException as e:
+                result = False
+                timeout_exception = e
+        # Handle sleep after
+        step_helper.handle_sleep(sleep_timing_type=step_settings.sleep_timing_type,
+                                 sleep_time=step_settings.sleep_time, step_executed=True)
+        # Handle result
+        result, step_message = step_helper.handle_step_result(step_result=result,
+                                                              invert_result=step_settings.invert_result,
+                                                              always_pass=step_settings.always_pass)
+        # Handle screenshot condition
+        screenshot = step_helper.take_screenshot(step_settings.screenshot_condition, result)
+
+        # Set the previous value of disable_reports.
+        self._driver.report().disable_reports(reports_disabled)
+
+        # Inferring function name - until / until not
+        function_name = ' '.join(function_name.split('_'))
+        # Getting all additional step information.
+        step_name, step_attributes = self.get_report_details(method)
+        self._driver.report().step(description=f'Wait {function_name} {step_name}',
+                                   message=f'{step_message}{os.linesep}',
+                                   passed=result,
+                                   inputs=step_attributes,
+                                   screenshot=screenshot)
+        # Always pass ignore result and thrown exception.
+        if step_settings.always_pass:
+            return True
+        # Raise exception if there was one.
+        if timeout_exception:
+            raise timeout_exception
+        return result
+
+    def get_report_details(self, method):
+        """Returns the inferred report details.
+
+        Attributes:
+            method: is a callable expected condition class.
+
+        Examples:
+            Assuming the method sent to the WebDriverWait's wait function is title_is(title="some title")...
+            The method class is name 'title_is' and the returned step_name will be 'title is'
+            The method attributes dict will be {"title": "some title"}
+
+        Returns:
+            step_name (str): The method class's name, underscores are replaces with spaces.
+            attributes_dict (dict): is all the method's attributes and their values.
+
+        """
+        step_name = ' '.join(method.__class__.__name__.split('_'))
+        attributes_dict = {attribute: json.dumps(getattr(method, attribute))
+                           for attribute in self.get_user_attributes(method)}
+        return step_name, attributes_dict
+
+    @staticmethod
+    def get_user_attributes(cls, exclude_methods=True) -> list:
+        """Gets a class's user defined attributes, ignores methods by default.
+
+        Examples:
+            Assuming we have the following class
+                class Foo:
+                    def __init__(self):
+                        self.a = 1
+                        self.b = 2
+
+                    def some_foo(self):
+                        pass
+
+            This function will return a list of ["a", "b"] and will ignore method 'some_foo' by default.
+
+        Returns a list of all user defined attributes in the class.
+
+        """
+        base_attrs = dir(type('dummy', (object,), {}))
+        this_cls_attrs = dir(cls)
+        res = []
+        for attr in this_cls_attrs:
+            if base_attrs.count(attr) or (callable(getattr(cls, attr)) and exclude_methods):
+                continue
+            res += [attr]
+        return res
+
+    @property
+    def driver(self):
+        """Getter for the driver."""
+        return self._driver

--- a/src/testproject/enums/findbytype.py
+++ b/src/testproject/enums/findbytype.py
@@ -18,15 +18,20 @@ from enum import Enum, unique
 @unique
 class FindByType(Enum):
     """Enumeration of supported element locator strategies"""
-    ID = 0
-    NAME = 1
-    CLASSNAME = 2
-    CSSSELECTOR = 3
-    LINKTEXT = 4
-    PARTIALLINKTEXT = 5
-    TAG_NAME = 6
-    XPATH = 7
-    ACCESSIBILITYID = 8
-    IOSUIAUTOMATION = 9
-    ANDROIDUIAUTOMATOR = 10
-    NAMEDTEXTFIELD = 11
+    ID = "id"
+    NAME = "name"
+    CLASSNAME = "class name"
+    CSSSELECTOR = "css selector"
+    LINKTEXT = "link text"
+    PARTIALLINKTEXT = "partial link text"
+    TAG_NAME = "tag name"
+    XPATH = "xpath"
+    ACCESSIBILITYID = "accessibility id"
+    IOSUIAUTOMATION = "-ios uiautomation"
+    ANDROIDUIAUTOMATOR = "-android uiautomator"
+    IOSPREDICATE = "-ios predicate string"
+    IOSCLASSCHAIN = "-ios class chain"
+
+    @classmethod
+    def has_value(cls, value):
+        return value in cls._value2member_map_

--- a/src/testproject/helpers/step_helper.py
+++ b/src/testproject/helpers/step_helper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
 from time import sleep
 
 from selenium.webdriver.remote.command import Command
@@ -59,3 +60,27 @@ class StepHelper:
             return False
         return False
 
+    @staticmethod
+    def handle_step_result(step_result: bool, base_msg: str = None, invert_result: bool = False,
+                           always_pass: bool = False) -> tuple:
+        """Handles the step result.
+
+        Returns a tuple of the changed result and a formatted step message for reporting.
+        """
+        result_str, result_opposite_str = ('Passed', 'Failed') if step_result else ('Failed', 'Passed')
+        invert_msg = f'Step result {result_str} inverted to {result_opposite_str}.{os.linesep}' if invert_result else ''
+        failure_behavior_msg = (f'Failure behaviour \'Always Pass\' is configured,'
+                                f' step result is forcibly set as Passed.{os.linesep}'
+                                if always_pass else '')
+        # Create a base message if none was provided.
+        base_msg = base_msg if base_msg else f'Step {result_str}.'
+        # Add a line break to the base message.
+        base_msg = base_msg if base_msg.endswith(os.linesep) else base_msg + os.linesep
+
+        # Handle invert result
+        step_result = not step_result if invert_result else step_result
+
+        # Handle always pass
+        step_result = True if always_pass else step_result
+
+        return step_result, f'{base_msg}{invert_msg}{failure_behavior_msg}'

--- a/src/testproject/helpers/step_helper.py
+++ b/src/testproject/helpers/step_helper.py
@@ -17,7 +17,7 @@ from time import sleep
 from selenium.webdriver.remote.command import Command
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
-from src.testproject.enums import SleepTimingType
+from src.testproject.enums import SleepTimingType, TakeScreenshotConditionType
 
 
 class StepHelper:
@@ -45,3 +45,17 @@ class StepHelper:
                     logging.debug(f'Step is designed to sleep for {sleep_time} milliseconds'
                                   f' {sleep_timing_type.name} execution.')
                     sleep(sleep_time / 1000.0)
+
+    @staticmethod
+    def take_screenshot(take_screenshot_condition: TakeScreenshotConditionType, passed: bool) -> bool:
+        """Returns true if the step report should include screenshot."""
+        if take_screenshot_condition is TakeScreenshotConditionType.Always:
+            return True
+        if take_screenshot_condition is TakeScreenshotConditionType.Never:
+            return False
+        if passed and (take_screenshot_condition is TakeScreenshotConditionType.Success):
+            return True
+        if not passed and (take_screenshot_condition is TakeScreenshotConditionType.Failure):
+            return False
+        return False
+

--- a/src/testproject/helpers/step_helper.py
+++ b/src/testproject/helpers/step_helper.py
@@ -34,7 +34,9 @@ class StepHelper:
             else:
                 self.executor.execute(Command.IMPLICIT_WAIT, {'sessionId': session_id, 'ms': float(timeout)})
 
-    def handle_sleep(self, sleep_timing_type, sleep_time, command, step_executed=False):
+    @staticmethod
+    def handle_sleep(sleep_timing_type, sleep_time, command=None, step_executed=False):
+        """Handles step sleep before/after step execution."""
         # Sleep Before if not Quit command
         if command is not Command.QUIT:
             if sleep_timing_type:

--- a/src/testproject/rest/messages/drivercommandreport.py
+++ b/src/testproject/rest/messages/drivercommandreport.py
@@ -22,6 +22,7 @@ class DriverCommandReport:
         result (dict): The result of the command that was executed
         passed (bool): Indication whether or not command execution was performed successfully
         screenshot (str): Screenshot as base64 encoded string
+        message (str): The message to include in the result
 
     Attributes:
         _command (str): The name of the command that was executed
@@ -29,6 +30,7 @@ class DriverCommandReport:
         _result (dict): The result of the command that was executed
         _passed (bool): Indication whether or not command execution was performed successfully
         _screenshot (str): Screenshot as base64 encoded string
+        _message (str): The message to include in the result
     """
 
     def __init__(
@@ -38,12 +40,14 @@ class DriverCommandReport:
         result: dict,
         passed: bool,
         screenshot: str = None,
+        message: str = None
     ):
         self._command = command
         self._command_params = command_params
         self._result = result
         self._passed = passed
         self._screenshot = screenshot
+        self._message = message
 
     @property
     def command(self) -> str:
@@ -75,6 +79,16 @@ class DriverCommandReport:
         """Setter for the screenshot property"""
         self._screenshot = value
 
+    @property
+    def message(self) -> str:
+        """Getter for the message property"""
+        return self._message
+
+    @message.setter
+    def message(self, value: str):
+        """Setter for the message property"""
+        self._message = value
+
     def to_json(self):
         """Creates a JSON representation of the current DriverCommandReport instance
 
@@ -82,15 +96,13 @@ class DriverCommandReport:
                 dict: JSON representation of the current instance
         """
         payload = {
-            "commandName": self._command,
-            "commandParameters": self._command_params,
-            "result": self._result,
-            "passed": self._passed,
+            "commandName": self.command,
+            "commandParameters": self.command_params,
+            "result": self.result,
+            "passed": self.passed,
+            "message": self.message,
+            "screenshot": self.screenshot
         }
-
-        # Add screenshot to report if it is provided
-        if self._screenshot is not None:
-            payload["screenshot"] = self._screenshot
 
         return payload
 
@@ -101,9 +113,11 @@ class DriverCommandReport:
 
         return (
             self._command == other._command
-            and self._command_params == other._command_params
-            and self._result == other._result
-            and self._passed == other._passed
+            and self.command_params == other.command_params
+            and self.result == other.result
+            and self.passed == other.passed
+            and self.message == other.message
+            and self.screenshot == other.screenshot
         )
 
     def __hash__(self):
@@ -115,5 +129,6 @@ class DriverCommandReport:
                 self.result,
                 self.passed,
                 self.screenshot,
+                self.message
             )
         )

--- a/src/testproject/rest/messages/stepreport.py
+++ b/src/testproject/rest/messages/stepreport.py
@@ -14,6 +14,8 @@
 
 import uuid
 
+from src.testproject.classes import ElementSearchCriteria
+
 
 class StepReport:
     """Payload object sent to the Agent when reporting a test step.
@@ -23,19 +25,29 @@ class StepReport:
             message (str): A message that goes with the step
             passed (bool): True if the step should be marked as passed, False otherwise
             screenshot (str): A base64 encoded screenshot that is associated with the step
+            element (ElementSearchCriteria): The step's element search criteria.
+            inputs (dict): Dictionary of step input parameters - name:value
+            outputs (dict): Dictionary of step output parameters - name:value
 
         Attributes:
             _description (str): The step description
             _message (str): A message that goes with the step
             _passed (bool): True if the step should be marked as passed, False otherwise
             _screenshot (str): A base64 encoded screenshot that is associated with the step
+            _element (dict): The step's element search criteria in JSON representation.
+            _input_params (dict): Dictionary of step input parameters - name:value
+            _output_params (dict): Dictionary of step output parameters - name:value
     """
 
-    def __init__(self, description: str, message: str, passed: bool, screenshot: str = None):
+    def __init__(self, description: str, message: str, passed: bool, screenshot: str = None,
+                 element: ElementSearchCriteria = None, inputs: dict = None, outputs: dict = None):
         self._description = description
         self._message = message
         self._passed = passed
         self._screenshot = screenshot
+        self._element = element.to_json() if element else None
+        self._input_params = inputs
+        self._output_params = outputs
 
     def to_json(self) -> dict:
         """Generates a dict containing the JSON representation of the step payload"""
@@ -44,8 +56,10 @@ class StepReport:
             "description": self._description,
             "message": self._message,
             "passed": self._passed,
+            "element": self._element,
+            "screenshot": self._screenshot,
+            "inputParameters": self._input_params,
+            "outputParameters": self._output_params
         }
-        if self._screenshot is not None:
-            json["screenshot"] = self._screenshot
 
         return json

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -32,8 +32,8 @@ class BaseDriver(RemoteWebDriver):
     Args:
         capabilities (dict): Automation session desired capabilities and options
         token (str): Developer token to be used to communicate with the Agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
 
     Attributes:
@@ -51,8 +51,8 @@ class BaseDriver(RemoteWebDriver):
         self,
         capabilities: dict,
         token: str,
-        projectname: str,
-        jobname: str,
+        project_name: str,
+        job_name: str,
         disable_reports: bool,
     ):
 
@@ -68,22 +68,22 @@ class BaseDriver(RemoteWebDriver):
 
         if disable_reports:
             # Setting the project and job name to empty strings will cause the Agent to not initialize a report
-            self._projectname = ""
-            self._jobname = ""
+            self._project_name = ""
+            self._job_name = ""
         else:
-            self._projectname = (
-                projectname
-                if projectname is not None
+            self._project_name = (
+                project_name
+                if project_name is not None
                 else ReportHelper.infer_project_name()
             )
-            self._jobname = (
-                jobname if jobname is not None else ReportHelper.infer_job_name()
+            self._job_name = (
+                job_name if job_name is not None else ReportHelper.infer_job_name()
             )
 
         self._agent_client: AgentClient = AgentClient(
             token=self._token,
             capabilities=capabilities,
-            report_settings=ReportSettings(self._projectname, self._jobname),
+            report_settings=ReportSettings(self._project_name, self._job_name),
         )
         self._agent_session: AgentSession = self._agent_client.agent_session
         self.w3c = True if self._agent_session.dialect == "W3C" else False

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import time
 
 from src.testproject.classes import StepSettings
 from src.testproject.enums import EnvironmentVariable
@@ -139,6 +140,36 @@ class BaseDriver(RemoteWebDriver):
             AddonHelper: object giving access to addon proxy methods
         """
         return AddonHelper(self._agent_client, self.command_executor)
+
+    def pause(self, milliseconds: int):
+        """Pause test execution for the specified duration
+
+        Args:
+            milliseconds (int): Number of milliseconds to pause test execution for
+        """
+
+        # Handling sleep before execution
+        self.command_executor.step_helper.handle_sleep(sleep_timing_type=self.step_settings.sleep_timing_type,
+                                                       sleep_time=self.step_settings.sleep_time)
+        # Sleep for...
+        time.sleep(milliseconds / 1000.0)
+
+        # Handling sleep after execution
+        self.command_executor.step_helper.handle_sleep(sleep_timing_type=self.step_settings.sleep_timing_type,
+                                                       sleep_time=self.step_settings.sleep_time,
+                                                       step_executed=True)
+        result, step_message = self.command_executor.step_helper.handle_step_result(
+            step_result=True,
+            invert_result=self.step_settings.invert_result,
+            always_pass=self.step_settings.always_pass)
+
+        # Handle screenshot condition
+        screenshot = self.command_executor.step_helper.take_screenshot(self.step_settings.screenshot_condition, result)
+        self.report().step(description=f'Pause for {{{{{milliseconds}}}}} ms',
+                           message=step_message,
+                           inputs={"milliseconds": milliseconds},
+                           passed=result,
+                           screenshot=screenshot)
 
     def quit(self):
         """Quits the driver and stops the session with the Agent, cleaning up after itself"""

--- a/src/testproject/sdk/drivers/webdriver/chrome.py
+++ b/src/testproject/sdk/drivers/webdriver/chrome.py
@@ -23,8 +23,8 @@ class Chrome(BaseDriver):
         chrome_options (ChromeOptions): Chrome automation session desired capabilities and options
         desired_capabilities (dict): Dictionary object containing desired capabilities for Chrome automation session
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -33,8 +33,8 @@ class Chrome(BaseDriver):
         chrome_options: ChromeOptions = None,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         # If no options or capabilities are specified at all, use default ChromeOptions
@@ -51,7 +51,7 @@ class Chrome(BaseDriver):
         super().__init__(
             capabilities=caps,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/drivers/webdriver/edge.py
+++ b/src/testproject/sdk/drivers/webdriver/edge.py
@@ -23,8 +23,8 @@ class Edge(BaseDriver):
         edge_options (Options): Edge automation session desired capabilities and options
         desired_capabilities (dict): Dictionary object containing desired capabilities for Chrome automation session
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -33,8 +33,8 @@ class Edge(BaseDriver):
         edge_options: Options = None,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         # If no options or capabilities are specified at all, use default Options
@@ -51,7 +51,7 @@ class Edge(BaseDriver):
         super().__init__(
             capabilities=caps,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/drivers/webdriver/firefox.py
+++ b/src/testproject/sdk/drivers/webdriver/firefox.py
@@ -23,8 +23,8 @@ class Firefox(BaseDriver):
         firefox_options (FirefoxOptions): Edge automation session desired capabilities and options
         desired_capabilities (dict): Dictionary object containing desired capabilities for Firefox automation session
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -33,8 +33,8 @@ class Firefox(BaseDriver):
         firefox_options: FirefoxOptions = None,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         # If no options or capabilities are specified at all, use default FirefoxOptions
@@ -51,7 +51,7 @@ class Firefox(BaseDriver):
         super().__init__(
             capabilities=caps,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/drivers/webdriver/ie.py
+++ b/src/testproject/sdk/drivers/webdriver/ie.py
@@ -23,8 +23,8 @@ class Ie(BaseDriver):
         ie_options (Options): IE automation session desired capabilities and options
         desired_capabilities (dict): Dictionary object containing desired capabilities for IE automation session
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -33,8 +33,8 @@ class Ie(BaseDriver):
         ie_options: Options = None,
         desired_capabilities: dict = None,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         # If no options or capabilities are specified at all, use default Options
@@ -51,7 +51,7 @@ class Ie(BaseDriver):
         super().__init__(
             capabilities=caps,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/drivers/webdriver/remote.py
+++ b/src/testproject/sdk/drivers/webdriver/remote.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import time
 
 from appium.webdriver.webdriver import WebDriver as AppiumWebDriver
 
@@ -134,6 +135,36 @@ class Remote(AppiumWebDriver):
             AddonHelper: object giving access to addon proxy methods
         """
         return AddonHelper(self._agent_client, self.command_executor)
+
+    def pause(self, milliseconds: int):
+        """Pause test execution for the specified duration
+
+        Args:
+            milliseconds (int): Number of milliseconds to pause test execution for
+        """
+
+        # Handling sleep before execution
+        self.command_executor.step_helper.handle_sleep(sleep_timing_type=self.step_settings.sleep_timing_type,
+                                                       sleep_time=self.step_settings.sleep_time)
+        # Sleep for...
+        time.sleep(milliseconds / 1000.0)
+
+        # Handling sleep after execution
+        self.command_executor.step_helper.handle_sleep(sleep_timing_type=self.step_settings.sleep_timing_type,
+                                                       sleep_time=self.step_settings.sleep_time,
+                                                       step_executed=True)
+        result, step_message = self.command_executor.step_helper.handle_step_result(
+            step_result=True,
+            invert_result=self.step_settings.invert_result,
+            always_pass=self.step_settings.always_pass)
+
+        # Handle screenshot condition
+        screenshot = self.command_executor.step_helper.take_screenshot(self.step_settings.screenshot_condition, result)
+        self.report().step(description=f'Pause for {{{{{milliseconds}}}}} ms',
+                           message=step_message,
+                           inputs={"milliseconds": milliseconds},
+                           passed=result,
+                           screenshot=screenshot)
 
     def quit(self):
         """Quits the driver and stops the session with the Agent, cleaning up after itself."""

--- a/src/testproject/sdk/drivers/webdriver/safari.py
+++ b/src/testproject/sdk/drivers/webdriver/safari.py
@@ -22,8 +22,8 @@ class Safari(BaseDriver):
     Args:
         desired_capabilities (dict): Safari automation session desired capabilities and options
         token (str): The developer token used to communicate with the agent
-        projectname (str): Project name to report
-        jobname (str): Job name to report
+        project_name (str): Project name to report
+        job_name (str): Job name to report
         disable_reports (bool): set to True to disable all reporting (no report will be created on TestProject)
     """
 
@@ -31,14 +31,14 @@ class Safari(BaseDriver):
         self,
         desired_capabilities: dict = DesiredCapabilities.SAFARI,
         token: str = None,
-        projectname: str = None,
-        jobname: str = None,
+        project_name: str = None,
+        job_name: str = None,
         disable_reports: bool = False,
     ):
         super().__init__(
             capabilities=desired_capabilities,
             token=token,
-            projectname=projectname,
-            jobname=jobname,
+            project_name=project_name,
+            job_name=job_name,
             disable_reports=disable_reports,
         )

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -390,6 +390,7 @@ class AgentClient:
             "POST",
             urljoin(self._remote_address, Endpoint.AddonExecution.value),
             self._create_action_proxy_payload(action),
+            {"skipReporting": "true"}  # Skip local reporting (done by the SDK).
         )
 
         if operation_result.status_code == HTTPStatus.NOT_FOUND:

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -191,18 +191,21 @@ class AgentClient:
         )
         return start_session_response
 
-    def send_request(self, method, path, body=None) -> OperationResult:
+    def send_request(self, method, path, body=None, params=None) -> OperationResult:
         """Sends HTTP request to Agent
 
         Args:
             method (str): HTTP method (GET, POST, ...)
             path (str): Relative API route path
             body (dict): Request body
+            params (dict): Request parameters
 
         Returns:
             OperationResult: contains result of the sent request
         """
         with requests.Session() as session:
+            if params:
+                session.params = params
             if method == "GET":
                 response = session.get(path, headers={"Authorization": self._token})
             elif method == "POST":

--- a/src/testproject/sdk/internal/reporter/reporter.py
+++ b/src/testproject/sdk/internal/reporter/reporter.py
@@ -15,6 +15,7 @@
 import logging
 import os
 
+from src.testproject.classes import ElementSearchCriteria
 from src.testproject.helpers import ReportHelper
 from src.testproject.rest.messages import StepReport, CustomTestReport
 
@@ -33,7 +34,8 @@ class Reporter:
         self._command_executor = command_executor
 
     def step(
-        self, description: str, message: str, passed: bool, screenshot: bool = False
+        self, description: str, message: str, passed: bool, screenshot: bool = False,
+            element: ElementSearchCriteria = None, inputs: dict = None, outputs: dict = None
     ):
         """Sends a step report to the Agent Client
 
@@ -42,6 +44,9 @@ class Reporter:
             message (str): A message that goes with the step
             passed (bool): True if the step should be marked as passed, False otherwise
             screenshot (bool): True if a screenshot should be made, False otherwise
+            element (ElementSearchCriteria): The step's element search criteria.
+            inputs (dict): Input parameters associated with the step
+            outputs (dict): Output parameters associated with the step
         """
 
         # First update the current test name and report a test if necessary
@@ -54,6 +59,9 @@ class Reporter:
                 message,
                 passed,
                 self._command_executor.create_screenshot() if screenshot else None,
+                element,
+                inputs,
+                outputs,
             )
             self._command_executor.agent_client.report_step(step_report)
         else:

--- a/tests/ci/headless/chrome_addon_proxy_test.py
+++ b/tests/ci/headless/chrome_addon_proxy_test.py
@@ -25,7 +25,7 @@ from selenium.webdriver import ChromeOptions
 def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/chrome_basic_test.py
+++ b/tests/ci/headless/chrome_basic_test.py
@@ -23,7 +23,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/chrome_multiple_test.py
+++ b/tests/ci/headless/chrome_multiple_test.py
@@ -28,7 +28,7 @@ if version.parse(ConfigHelper.get_sdk_version()) < version.parse("0.64.0"):
 def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/chrome_no_options_or_caps_test.py
+++ b/tests/ci/headless/chrome_no_options_or_caps_test.py
@@ -20,7 +20,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(projectname="CI - Python")
+    driver = webdriver.Chrome(project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/chrome_step_settings_test.py
+++ b/tests/ci/headless/chrome_step_settings_test.py
@@ -26,7 +26,7 @@ from tests.pageobjects.web import LoginPage
 def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/cloud_basic_test.py
+++ b/tests/ci/headless/cloud_basic_test.py
@@ -25,7 +25,7 @@ def driver():
     chrome_options = ChromeOptions()
     chrome_options.headless = True
     chrome_options.set_capability("cloud:URL", os.getenv("TP_CLOUD_URL"))
-    driver = webdriver.Chrome(chrome_options=chrome_options, projectname="CI - Python")
+    driver = webdriver.Chrome(chrome_options=chrome_options, project_name="CI - Python")
     yield driver
     driver.quit()
 

--- a/tests/ci/headless/firefox_basic_test.py
+++ b/tests/ci/headless/firefox_basic_test.py
@@ -24,7 +24,7 @@ def driver():
     firefox_options = Options()
     firefox_options.add_argument("-headless")
     driver = webdriver.Firefox(
-        firefox_options=firefox_options, projectname="CI - Python"
+        firefox_options=firefox_options, project_name="CI - Python"
     )
     yield driver
     driver.quit()

--- a/tests/ci/unittests/rest/messages/drivercommandreport_test.py
+++ b/tests/ci/unittests/rest/messages/drivercommandreport_test.py
@@ -70,6 +70,8 @@ def test_to_json(dcr):
         "commandParameters": {"param": "value"},
         "result": {"result": "value"},
         "passed": True,
+        "screenshot": None,
+        "message": None
     }
 
 
@@ -80,4 +82,5 @@ def test_to_json_with_screenshot(dcr_with_screenshot):
         "result": {"result": "value"},
         "passed": False,
         "screenshot": "base64_screenshot",
+        "message": None
     }

--- a/tests/ci/unittests/rest/messages/stepreport_test.py
+++ b/tests/ci/unittests/rest/messages/stepreport_test.py
@@ -28,6 +28,10 @@ def test_to_json_without_screenshot(mocker):
         "description": "my_description",
         "message": "my_message",
         "passed": True,
+        "element": None,
+        "inputParameters": None,
+        "outputParameters": None,
+        "screenshot": None
     }
 
 
@@ -44,5 +48,8 @@ def test_to_json_with_screenshot(mocker):
         "description": "another_description",
         "message": "another_message",
         "passed": False,
+        "element": None,
+        "inputParameters": None,
+        "outputParameters": None,
         "screenshot": "base64_screenshot_here",
     }

--- a/tests/examples/drivers/web/chrome_driver_test.py
+++ b/tests/examples/drivers/web/chrome_driver_test.py
@@ -21,7 +21,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(chrome_options=ChromeOptions(), projectname="Examples", jobname=None)
+    driver = webdriver.Chrome(chrome_options=ChromeOptions(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/drivers/web/edge_driver_test.py
+++ b/tests/examples/drivers/web/edge_driver_test.py
@@ -21,7 +21,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Edge(edge_options=Options(), projectname="Examples", jobname=None)
+    driver = webdriver.Edge(edge_options=Options(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/drivers/web/firefox_driver_test.py
+++ b/tests/examples/drivers/web/firefox_driver_test.py
@@ -21,7 +21,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Firefox(firefox_options=Options(), projectname="Examples", jobname=None)
+    driver = webdriver.Firefox(firefox_options=Options(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/drivers/web/ie_driver_test.py
+++ b/tests/examples/drivers/web/ie_driver_test.py
@@ -21,7 +21,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Ie(ie_options=Options(), projectname="Examples", jobname=None)
+    driver = webdriver.Ie(ie_options=Options(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/drivers/web/safari_driver_test.py
+++ b/tests/examples/drivers/web/safari_driver_test.py
@@ -20,7 +20,7 @@ from tests.pageobjects.web import LoginPage, ProfilePage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Safari(projectname="Examples", jobname=None)
+    driver = webdriver.Safari(project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/reports/manual_reporting_test.py
+++ b/tests/examples/reports/manual_reporting_test.py
@@ -14,6 +14,8 @@
 
 import pytest
 
+from src.testproject.classes import ElementSearchCriteria
+from src.testproject.enums import FindByType
 from src.testproject.sdk.drivers import webdriver
 from tests.pageobjects.web import LoginPage, ProfilePage
 
@@ -28,7 +30,6 @@ def driver():
 
 
 def test_is_reported_as_passed(driver):
-
     LoginPage(driver).open().login_as("John Smith", "12345")
     assert ProfilePage(driver).greetings_are_displayed() is True
     driver.report().test(name="Passing test", passed=True)
@@ -42,5 +43,7 @@ def test_is_reported_as_failed_with_additional_step(driver):
         message="An additional message that goes with the step",
         passed=False,
         screenshot=True,
+        element=ElementSearchCriteria(FindByType.ID, "the_ID_value"),
+        inputs={"parameter_name_x": "any_object_value_of_x", "another_parameter_y": True}
     )
     driver.report().test(name="Failing test", passed=False)

--- a/tests/examples/reports/report_failed_pytest_assertion_test.py
+++ b/tests/examples/reports/report_failed_pytest_assertion_test.py
@@ -22,7 +22,7 @@ from tests.pageobjects.web import LoginPage
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(chrome_options=ChromeOptions(), projectname="Examples", jobname=None)
+    driver = webdriver.Chrome(chrome_options=ChromeOptions(), project_name="Examples", job_name=None)
     yield driver
     driver.quit()
 

--- a/tests/examples/reports/report_failed_unittest_assertion_test.py
+++ b/tests/examples/reports/report_failed_unittest_assertion_test.py
@@ -23,7 +23,7 @@ from tests.pageobjects.web import LoginPage
 class TestBasic(unittest.TestCase):
     def setUp(self):
         self.driver = webdriver.Chrome(
-            chrome_options=ChromeOptions(), projectname="Examples", jobname=None
+            chrome_options=ChromeOptions(), project_name="Examples", job_name=None
         )
 
     @report_assertion_errors

--- a/tests/examples/web_driver_wait/web_driver_wait_test.py
+++ b/tests/examples/web_driver_wait/web_driver_wait_test.py
@@ -1,0 +1,50 @@
+# Copyright 2020 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+# Notice we import WebDriverWait from SDK classes!
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+
+from src.testproject.classes import WebDriverWait
+from src.testproject.sdk.drivers import webdriver
+from selenium.webdriver.support import expected_conditions as ec
+
+
+@pytest.fixture
+def browser():
+    driver = webdriver.Chrome()
+    yield driver
+    driver.quit()
+
+
+@pytest.fixture()
+def wait(browser):
+    wait = WebDriverWait(browser, 2)  # Notice the imports, using WebDriverWait from 'src.testproject.classes'
+    yield wait
+
+
+def test_wait_with_ec_invisible(browser, wait):
+    # Driver command will fail because element will not be found but this is the expected result so this step actually
+    # passes and will reported as passed as well.
+    browser.get('http://www.google.com')
+    search_field = (By.CSS_SELECTOR, "input[name='z']")  # => z should be q, thus simulating a non-present element
+    element_not_present = wait.until(ec.invisibility_of_element_located(search_field))
+    assert element_not_present
+    # This step will fail because google's title is not the one we give below, step will be reported as failed
+    # and a TimeoutException will arose by the WebDriverWait instance.
+    try:
+        wait.until(ec.title_is("Title that is definitely not this one."))
+    except TimeoutException:
+        pass

--- a/tests/internal/addon_invert_result_test.py
+++ b/tests/internal/addon_invert_result_test.py
@@ -11,8 +11,8 @@ DEV_TOKEN = "kjvgLv5jxNuy5g48Nd2BMrOFG-kGdaZ86goeBjhsqts1"
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(token=DEV_TOKEN, projectname="Addon Invert Result Project",
-                              jobname="Addon Invert Result Job")
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Addon Invert Result Project",
+                              job_name="Addon Invert Result Job")
     yield driver
     driver.quit()
 

--- a/tests/internal/addon_invert_result_test.py
+++ b/tests/internal/addon_invert_result_test.py
@@ -4,9 +4,10 @@ from selenium.webdriver.common.by import By
 from proxy_examples.actions import TypeRandomPhoneAction
 from src.testproject.classes import DriverStepSettings, StepSettings
 from src.testproject.decorator import report
+from src.testproject.enums import TakeScreenshotConditionType
 from src.testproject.sdk.drivers import webdriver
 
-DEV_TOKEN = "kjvgLv5jxNuy5g48Nd2BMrOFG-kGdaZ86goeBjhsqts1"
+DEV_TOKEN = "ZNXf2v22_eXli4w4UsLM5ulkfxLHK1IqNSfHH7i2wyI1"
 
 
 @pytest.fixture
@@ -29,5 +30,10 @@ def test_report_decorator(driver):
     # The TypeRandomPhoneAction addon generates a unique phone number
     # and types that in the specified textfield
     # Inverting result using the StepSettings.
-    with DriverStepSettings(driver, StepSettings(invert_result=True)):
+    with DriverStepSettings(driver, StepSettings(invert_result=True,
+                                                 screenshot_condition=TakeScreenshotConditionType.Failure,
+                                                 always_pass=True)):
+        driver.addons().execute(TypeRandomPhoneAction("1", 10), *textfield_phone)
+    with DriverStepSettings(driver, StepSettings(invert_result=True,
+                                                 screenshot_condition=TakeScreenshotConditionType.Failure)):
         driver.addons().execute(TypeRandomPhoneAction("1", 10), *textfield_phone)

--- a/tests/internal/report_decorator_test.py
+++ b/tests/internal/report_decorator_test.py
@@ -8,7 +8,7 @@ DEV_TOKEN = "Hnw-B_FakRKt5Nar7jICIbHNTwBNW9Pp09MH_nXZTI41"
 
 @pytest.fixture
 def driver():
-    driver = webdriver.Chrome(token=DEV_TOKEN, projectname="Report Decorator Project", jobname="Report Decorator Job")
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Report Decorator Project", job_name="Report Decorator Job")
     yield driver
     driver.quit()
 

--- a/tests/internal/web_driver_wait_test.py
+++ b/tests/internal/web_driver_wait_test.py
@@ -1,0 +1,47 @@
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from src.testproject.classes import DriverStepSettings, StepSettings, WebDriverWait
+from src.testproject.enums import TakeScreenshotConditionType
+from src.testproject.sdk.drivers import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as ec
+
+DEV_TOKEN = "ZNXf2v22_eXli4w4UsLM5ulkfxLHK1IqNSfHH7i2wyI1"
+
+
+@pytest.fixture
+def browser():
+    driver = webdriver.Chrome(token=DEV_TOKEN, project_name="Web Driver Report Project",
+                              job_name="Web Driver Report Job")
+    yield driver
+    driver.quit()
+
+
+@pytest.fixture()
+def wait(browser):
+    wait = WebDriverWait(browser, 2)  # Notice the imports, using WebDriverWait from 'src.testproject.classes'
+    yield wait
+
+
+def test_wait_with_ec_invisible(browser, wait):
+    # Case 1 - Should report passed.
+    browser.get('http://www.google.com')
+    search_field = (By.CSS_SELECTOR, "input[name='z']")  # => z should be q, thus simulating a non-present element
+    element_not_present = wait.until(ec.invisibility_of_element_located(search_field))
+    assert element_not_present
+    # Case 2 - Should report failed.
+    try:
+        wait.until(ec.title_is("Title that is definitely not this one."))
+    except TimeoutException:
+        pass
+    # Case 3 - Report with StepSettings
+    # Inverting result and taking picture on success.
+    # Wait should timeout and report fail which will be inverted to passed and include picture.
+    with DriverStepSettings(driver=wait.driver,
+                            step_settings=StepSettings(invert_result=True,
+                                                       screenshot_condition=TakeScreenshotConditionType.Failure)):
+        try:
+            wait.until_not(ec.url_contains("google"))
+        except TimeoutException:
+            pass


### PR DESCRIPTION
This PR contains many changes, will try to summarize them in points.

- Added the 'Always Pass' failure behavior since this is a special case where the Step's result is forcibly reported as passed, all other cases should be handled by the user/code-generator.
- Expanding the manual step reporting, can add input/output parameters and the element used by the step.
- Expanding the driver command auto-reporting, can add additional message to the report.
- Addons are reported automatically by the SDK (instead of by the Agent previously).
- New class WebDriverWait to solve #50