### PR TITLE
Behave Reporting Support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.65.1] - 2021-01-25
+
+### Added
+
+- Support for Behave framework.
+
 ## [0.65.0] - 2021-01-06
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -419,6 +419,53 @@ If you wish, you can override the default log configuration:
 
 See `this page <https://docs.python.org/3/library/logging.html#logging-levels>`__ for a list of accepted logging levels and `look here <https://docs.python.org/3/howto/logging.html#changing-the-format-of-displayed-messages>`__ for more information on how to define a custom logging format.
 
+Behave Support
+--------------
+The SDK also supports automatic reporting of Behave features, scenarios and steps using the @behave_reporter decorator.
+
+It will disable the reporting of driver commands and automatic reporting of tests.
+Instead, it will report:
+
+* A test for every scenario in a feature file
+* All steps in a scenario as steps in the corresponding test
+* Steps are automatically marked as passed or failed, to create comprehensive living documentation from your
+  specifications on TestProject Cloud.
+
+To enable Behave feature reporting, in your environment.py decorate one or more of the following methods:
+
+* method used to initialize your driver (usually before_all or before_feature to store the driver in the behave context)
+* after_step
+* after_scenario
+
+    Storing the driver in the context provides direct access to the driver throughout the program
+    such as in the step implementations.
+
+.. code-block:: python
+
+    @behave_reporter
+    def before_all(context):
+        context.driver = webdriver.Chrome(projectname="Behave BDD")
+
+
+    @behave_reporter
+    def after_step(context, step):
+        pass
+
+
+    @behave_reporter
+    def after_scenario(context, scenario):
+        pass
+
+
+By default, screenshots are taken only when step fail in your test, if you would like to change
+the behavior to always take a screenshot, pass the screenshot argument as ``True`` in your decorator.
+
+.. code-block:: python
+
+    @behave_reporter(screenshot=True)
+    def after_step(context, step):
+        pass
+
 Examples
 --------
 Here is a list of all examples for the different drivers that are supported by this SDK:

--- a/src/testproject/decorator/behave_reporter.py
+++ b/src/testproject/decorator/behave_reporter.py
@@ -1,0 +1,68 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.testproject.helpers.activesessionhelper import get_active_driver_instance
+
+from functools import wraps
+from src.testproject.enums import EnvironmentVariable
+import os
+
+
+def behave_reporter(func=None, *, screenshot: bool = False):
+    """Enables automatic logging of Gherkin syntax, including a screenshot when screenshot argument is True, by default
+    screenshots are taken only when a step fails.
+    Args:
+            func: Original function wrapped by the annotation.
+            screenshot (bool): True if a screenshot should be taken for each step, otherwise (False) only on failure.
+    """
+    def _behave_reporter(_func):
+        @wraps(_func)
+        def wrapper(*args, **kwargs):
+            # Disable automatic test and command reporting.
+            if os.getenv("TP_DISABLE_AUTO_REPORTING") != "True":
+                os.environ[EnvironmentVariable.TP_DISABLE_AUTO_REPORTING.value] = "True"
+            # Report step or test based on the constant hook name.
+            # Behave always calls the methods with the arguments in the following order: (context, step/scenario).
+            hook_name = _func.__name__
+            if hook_name == "after_step":
+                driver = get_active_driver_instance()
+                step = args[1]
+                report_step(driver=driver, step=step, screenshot=screenshot)
+            if hook_name == "after_scenario":
+                driver = get_active_driver_instance()
+                scenario = args[1]
+                report_test(driver=driver, scenario=scenario)
+            return _func(*args, **kwargs)
+        return wrapper
+
+    if func:
+        return _behave_reporter(func)
+
+    return _behave_reporter
+
+
+def report_step(driver, step, screenshot):
+    """Report behave step """
+    step_description = "{} {}".format(step.keyword, step.name)
+    step_status = True if step.status == 'passed' else False
+    step_message = "{} {}".format(type(step.exception).__name__, str(step.exception)) if not step_status \
+        else step_description
+    driver.report().step(description=step_description, message=step_message, passed=step_status, screenshot=screenshot)
+
+
+def report_test(driver, scenario):
+    """Report behave scenario """
+    test_name = scenario.name
+    test_status = True if scenario.status == 'passed' else False
+    driver.report().test(name=test_name, passed=test_status)

--- a/src/testproject/decorator/report_assertion_errors.py
+++ b/src/testproject/decorator/report_assertion_errors.py
@@ -19,11 +19,7 @@ import sys
 import traceback
 from functools import wraps
 
-from src.testproject.sdk.exceptions import SdkException
-
-from src.testproject.sdk.drivers.webdriver import Remote, Generic
-
-from src.testproject.sdk.drivers.webdriver.base import BaseDriver
+from src.testproject.helpers.activesessionhelper import get_active_driver_instance
 
 
 def report_assertion_errors(func=None, *, screenshot: bool = False):
@@ -49,7 +45,7 @@ def report_assertion_errors(func=None, *, screenshot: bool = False):
                 )
 
                 _, line, function, text = tb_info[line_index]
-                driver = __get_active_driver_instance()
+                driver = get_active_driver_instance()
                 message = f"Assertion failed on line {line} in {function}"
                 description, message = __handle_step_report_details(description, message)
                 driver.report().step(
@@ -67,21 +63,6 @@ def report_assertion_errors(func=None, *, screenshot: bool = False):
         return _report_assertion_errors(func)
 
     return _report_assertion_errors
-
-
-def __get_active_driver_instance():
-    """Get the current driver instance in use (BaseDriver, Remote or Generic) """
-    driver = BaseDriver.instance()
-    if driver is None:
-        driver = Remote.instance()
-        if driver is None:
-            driver = Generic.instance()
-            if driver is None:
-                raise SdkException(
-                    "No active driver instance found, so cannot report failed assertion"
-                )
-
-    return driver
 
 
 def __handle_step_report_details(description, message):

--- a/src/testproject/enums/environmentvariable.py
+++ b/src/testproject/enums/environmentvariable.py
@@ -24,6 +24,7 @@ class EnvironmentVariable(Enum):
     TP_TEST_NAME = "TP_TEST_NAME"
     TP_PROJECT_NAME = "TP_PROJECT_NAME"
     TP_JOB_NAME = "TP_JOB_NAME"
+    TP_DISABLE_AUTO_REPORTING = "TP_DISABLE_AUTO_REPORTING"
 
     def remove(self):
         """Try and remove the environment variable, proceed if the variable doesn't exist"""

--- a/src/testproject/helpers/activesessionhelper.py
+++ b/src/testproject/helpers/activesessionhelper.py
@@ -1,0 +1,27 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.testproject.sdk.drivers.webdriver import Remote, Generic
+from src.testproject.sdk.drivers.webdriver.base import BaseDriver
+from src.testproject.sdk.exceptions import SdkException
+
+
+def get_active_driver_instance():
+    """Get the current driver instance in use (BaseDriver, Remote or Generic) """
+    # Get the first driver instance that exists (not None) in the list of possible driver instances.
+    driver = next((_driver for _driver in [BaseDriver.instance(), Remote.instance(), Generic.instance()] if _driver
+                  is not None), None)
+    if driver is None:
+        raise SdkException("No active driver instance found for reporting")
+    return driver

--- a/src/testproject/sdk/drivers/webdriver/base/basedriver.py
+++ b/src/testproject/sdk/drivers/webdriver/base/basedriver.py
@@ -24,6 +24,7 @@ from src.testproject.sdk.internal.helpers import CustomCommandExecutor
 from src.testproject.sdk.internal.reporter import Reporter
 from src.testproject.sdk.internal.session import AgentSession
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
+import os
 
 
 class BaseDriver(RemoteWebDriver):
@@ -97,6 +98,11 @@ class BaseDriver(RemoteWebDriver):
         )
 
         self.command_executor.disable_reports = disable_reports
+
+        # Disable automatic command and test reports if Behave reporting is enabled.
+        if os.getenv("TP_DISABLE_AUTO_REPORTING") == "True":
+            self.command_executor.disable_command_reports = True
+            self.command_executor.disable_auto_test_reports = True
 
         RemoteWebDriver.__init__(
             self,

--- a/src/testproject/sdk/drivers/webdriver/remote.py
+++ b/src/testproject/sdk/drivers/webdriver/remote.py
@@ -25,6 +25,7 @@ from src.testproject.sdk.internal.agent import AgentClient
 from src.testproject.sdk.internal.helpers import CustomAppiumCommandExecutor
 from src.testproject.sdk.internal.reporter import Reporter
 from src.testproject.sdk.internal.session import AgentSession
+import os
 
 
 class Remote(AppiumWebDriver):
@@ -102,6 +103,11 @@ class Remote(AppiumWebDriver):
 
         # this ensures that mobile-specific commands are also available for our command executor
         self._addCommands()
+
+        # Disable automatic command and test reports if Behave reporting is enabled.
+        if os.getenv("TP_DISABLE_AUTO_REPORTING") == "True":
+            self.command_executor.disable_command_reports = True
+            self.command_executor.disable_auto_test_reports = True
 
         Remote.__instance = self
 

--- a/tests/ci/headless/firefox_basic_test.py
+++ b/tests/ci/headless/firefox_basic_test.py
@@ -26,6 +26,7 @@ def driver():
     driver = webdriver.Firefox(
         firefox_options=firefox_options, projectname="CI - Python"
     )
+    driver.set_window_size(1920, 1080)
     yield driver
     driver.quit()
 

--- a/tests/examples/frameworks/behave/features/environment.py
+++ b/tests/examples/frameworks/behave/features/environment.py
@@ -1,0 +1,54 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.testproject.sdk.drivers import webdriver
+from src.testproject.decorator.behave_reporter import behave_reporter
+
+""" Executed once per test run: Before any features and scenarios are run.
+    Initialize the driver and start the session.
+"""
+
+
+@behave_reporter()
+def before_all(context):
+    context.driver = webdriver.Chrome(projectname="Python BDD", jobname="Behave")
+
+
+""" Executed after each step in the scenario.
+    Reports the test step.
+"""
+
+
+@behave_reporter(screenshot=True)
+def after_step(context, step):
+    pass
+
+
+""" Executed after each scenario in the feature.
+    Reports the scenario as a test.
+"""
+
+
+@behave_reporter
+def after_scenario(context, scenario):
+    pass
+
+
+""" Executed once per test run: after all features and scenarios are run.
+    Quit the driver and close the session.
+"""
+
+
+def after_all(context):
+    context.driver.quit()

--- a/tests/examples/frameworks/behave/features/selenium_test.feature
+++ b/tests/examples/frameworks/behave/features/selenium_test.feature
@@ -1,0 +1,20 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: TestProject with Behave Framework
+
+  Scenario: Run a Simple BDD test with TestProject
+     Given I navigate to the TestProject example page
+     When I perform a login
+     Then I should see a logout button

--- a/tests/examples/frameworks/behave/features/steps/step_definitions.py
+++ b/tests/examples/frameworks/behave/features/steps/step_definitions.py
@@ -1,0 +1,33 @@
+# Copyright 2021 TestProject (https://testproject.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from behave import given, when, then
+
+
+@given('I navigate to the TestProject example page')
+def step_impl_given(context):
+    context.driver.get("https://example.testproject.io/web/")
+
+
+@when('I perform a login')
+def step_impl_when(context):
+    context.driver.find_element_by_css_selector("#name").send_keys("John Smith")
+    context.driver.find_element_by_css_selector("#password").send_keys("12345")
+    context.driver.find_element_by_css_selector("#login").click()
+
+
+@then('I should see a logout button')
+def step_impl_then(context):
+    passed = context.driver.find_element_by_css_selector("#logout").is_displayed()
+    assert passed is True

--- a/tests/pageobjects/web/profile_page.py
+++ b/tests/pageobjects/web/profile_page.py
@@ -15,6 +15,8 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 from src.testproject.sdk.drivers.webdriver.base import BaseDriver
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 class ProfilePage:
@@ -38,7 +40,8 @@ class ProfilePage:
         return self._driver.find_element(*self.textlabel_saved).is_displayed()
 
     def update_profile(self, country: str, address: str, email: str, phone: str):
-        Select(self._driver.find_element(*self.dropdown_country)).select_by_visible_text(country)
+        country_dropdown = WebDriverWait(self._driver, 60).until(EC.element_to_be_clickable(self.dropdown_country))
+        Select(country_dropdown).select_by_visible_text(country)
         self._driver.find_element(*self.textfield_address).send_keys(address)
         self._driver.find_element(*self.textfield_email).send_keys(email)
         self._driver.find_element(*self.textfield_phone).send_keys(phone)


### PR DESCRIPTION
Added support for Behave Framework BDD reporting.

Users will need to use the decorator on the method they create the driver from.
As the driver can also be created in a fixture or any other method, I am not checking where before hooks for
driver creation.

After step and after scenario will construct the report for TestProject platform.
The user can insert his driver regularly into the Behave context, they will just need to use the report_behave decorator on the after_step and after_scenario hooks to enable the reporing into the platform.

Step failures will show the exception + error message.
