### PR TITLE
Adding query parameter to Addon execution in order to tell Agent to skip reporting.

### DIFF
--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -391,6 +391,7 @@ class AgentClient:
             "POST",
             urljoin(self._remote_address, Endpoint.AddonExecution.value),
             self._create_action_proxy_payload(action),
+            {"skipReporting": "true"}  # Skip local reporting (done by the SDK).
         )
 
         if operation_result.status_code == HTTPStatus.NOT_FOUND:

--- a/src/testproject/sdk/internal/agent/agent_client.py
+++ b/src/testproject/sdk/internal/agent/agent_client.py
@@ -192,18 +192,21 @@ class AgentClient:
         )
         return start_session_response
 
-    def send_request(self, method, path, body=None) -> OperationResult:
+    def send_request(self, method, path, body=None, params=None) -> OperationResult:
         """Sends HTTP request to Agent
 
         Args:
             method (str): HTTP method (GET, POST, ...)
             path (str): Relative API route path
             body (dict): Request body
+            params (dict): Request parameters
 
         Returns:
             OperationResult: contains result of the sent request
         """
         with requests.Session() as session:
+            if params:
+                session.params = params
             if method == "GET":
                 response = session.get(path, headers={"Authorization": self._token})
             elif method == "POST":


### PR DESCRIPTION
Agent will no longer report Addon execution steps.

This is done because the reporting in the Agent is limited to what the Agent knows about the execution.
Sometimes, there is a need to report the step differently, add screenshots or change the failure result, this can only be done by the SDK.

Therefore, in the next PR's addon execution will be reported from the SDK and not by the Agent.